### PR TITLE
Adds an option to allows only presets in the URL.

### DIFF
--- a/config.go
+++ b/config.go
@@ -180,7 +180,8 @@ type config struct {
 
 	BaseURL string
 
-	Presets presets
+	Presets     presets
+	OnlyPresets bool
 
 	WatermarkData    string
 	WatermarkPath    string
@@ -230,6 +231,7 @@ var conf = config{
 	SentryRelease:                  fmt.Sprintf("imgproxy/%s", version),
 	FreeMemoryInterval:             10,
 	BufferPoolCalibrationThreshold: 1024,
+	OnlyPresets:                    false,
 }
 
 func init() {
@@ -308,6 +310,7 @@ func init() {
 	conf.Presets = make(presets)
 	presetEnvConfig(conf.Presets, "IMGPROXY_PRESETS")
 	presetFileConfig(conf.Presets, *presetsPath)
+	boolEnvConfig(&conf.OnlyPresets, "IMGPROXY_ONLY_PRESETS")
 
 	strEnvConfig(&conf.WatermarkData, "IMGPROXY_WATERMARK_DATA")
 	strEnvConfig(&conf.WatermarkPath, "IMGPROXY_WATERMARK_PATH")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,6 +107,7 @@ There are two ways to define presets:
 ##### Using an environment variable
 
 * `IMGPROXY_PRESETS`: set of preset definitions, comma-divided. Example: `default=resizing_type:fill/enlarge:1,sharp=sharpen:0.7,blurry=blur:2`. Default: blank.
+* `IMGPROXY_ONLY_PRESETS`: disable all URL formats but presets. In this case, you always need to inform a valid preset. Example: `http://imgproxy.example.com/unsafe/thumbnail/plain/http://example.com/images/curiosity.jpg@png`
 
 ##### Using a command line argument
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -21,3 +21,11 @@ Read how to specify your presets with imgproxy in the [Configuration](./configur
 ### Default preset
 
 A preset named `default` will be applied to each image. Useful in case you want your default processing options to be different from the imgproxy default ones.
+
+### Only presets
+
+If you set `IMGPROXY_ONLY_PRESETS` as `true`, a preset is obligatory, and all other URL formats are disabled.
+
+In this case, you always need to inform a preset in your URLs without the `preset` or `pr` statement. Example: `http://imgproxy.example.com/AfrOrF3gWeDA6VOlDG4TzxMv39O7MXnF4CXpKUwGqRM/thumbnail/aHR0cDovL2V4YW1w/bGUuY29tL2ltYWdl/cy9jdXJpb3NpdHku/anBn.png`
+
+It's possible to use more than one preset separing them with `:` like `thumbnail:gray`.

--- a/processing_options.go
+++ b/processing_options.go
@@ -714,6 +714,16 @@ func parseURLOptions(opts []string) (urlOptions, []string) {
 	for i, opt := range opts {
 		args := strings.Split(opt, ":")
 
+		if conf.OnlyPresets {
+			if i > 0 {
+				break
+			}
+
+			parsed["preset"] = args
+			urlStart = i + 1
+			break
+		}
+
 		if len(args) == 1 {
 			urlStart = i
 			break

--- a/processing_options_test.go
+++ b/processing_options_test.go
@@ -564,6 +564,46 @@ func (s *ProcessingOptionsTestSuite) TestParsePathSignedInvalid() {
 	assert.Equal(s.T(), errInvalidSignature.Error(), err.Error())
 }
 
+func (s *ProcessingOptionsTestSuite) TestParsePathOnlyPresets() {
+	conf.OnlyPresets = true
+	conf.Presets["test1"] = urlOptions{
+		"blur": []string{"0.2"},
+	}
+	conf.Presets["test2"] = urlOptions{
+		"quality": []string{"50"},
+	}
+
+	req := s.getRequest("http://example.com/unsafe/test1:test2/plain/http://images.dev/lorem/ipsum.jpg")
+
+	ctx, err := parsePath(context.Background(), req)
+
+	require.Nil(s.T(), err)
+
+	po := getProcessingOptions(ctx)
+	assert.Equal(s.T(), float32(0.2), po.Blur)
+	assert.Equal(s.T(), 50, po.Quality)
+}
+
+func (s *ProcessingOptionsTestSuite) TestParseBase64URLOnlyPresets() {
+	conf.OnlyPresets = true
+	conf.Presets["test1"] = urlOptions{
+		"blur": []string{"0.2"},
+	}
+	conf.Presets["test2"] = urlOptions{
+		"quality": []string{"50"},
+	}
+
+	imageURL := "http://images.dev/lorem/ipsum.jpg?param=value"
+	req := s.getRequest(fmt.Sprintf("http://example.com/unsafe/test1:test2/%s.png", base64.RawURLEncoding.EncodeToString([]byte(imageURL))))
+
+	ctx, err := parsePath(context.Background(), req)
+
+	require.Nil(s.T(), err)
+
+	po := getProcessingOptions(ctx)
+	assert.Equal(s.T(), float32(0.2), po.Blur)
+	assert.Equal(s.T(), 50, po.Quality)
+}
 func TestProcessingOptions(t *testing.T) {
 	suite.Run(t, new(ProcessingOptionsTestSuite))
 }


### PR DESCRIPTION
If you set `IMGPROXY_ONLY_PRESETS` as `true`, a preset is obligatory, and all other URL formats are disabled.

In this case, you always need to inform a preset in your URLs without the `preset` or `pr` statement. Example: `http://imgproxy.example.com/AfrOrF3gWeDA6VOlDG4TzxMv39O7MXnF4CXpKUwGqRM/thumbnail/aHR0cDovL2V4YW1w/bGUuY29tL2ltYWdl/cy9jdXJpb3NpdHku/anBn.png`

It's possible to use more than one preset separing them with `:` like `thumbnail:gray`.