### PR TITLE
Add link to imgproxy package in AUR for Arch Linux users

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-There are three ways you can install imgproxy:
+There are four ways you can install imgproxy:
 
 ### Docker
 
@@ -32,6 +32,12 @@ $ heroku create your-application
 $ heroku stack:set container
 $ git push heroku master
 ```
+
+### Packages
+
+#### Arch Linux and derivatives
+
+[imgproxy](https://aur.archlinux.org/packages/imgproxy/) package is available from AUR.
 
 ### From the source
 


### PR DESCRIPTION
Fun fact: actually AUR doesn't contain packages and software is being build every time from the sources on end user's machine. So it is long and loud process. But it is as simple as package manager – you just check imgproxy and it will be installed for you along with libvips.