### PR TITLE
Fixed browser usage

### DIFF
--- a/examples/signature.js
+++ b/examples/signature.js
@@ -1,16 +1,16 @@
-const crypto = require('crypto')
+const createHmac = require('create-hmac')
 
 const KEY = '943b421c9eb07c830af81030552c86009268de4e532ba2ee2eab8247c6da0881'
 const SALT = '520f986b998545b4785e0defbc4f3c1203f22de2374a3d53cb7a7fe9fea309c5'
 
 const urlSafeBase64 = (string) => {
-  return new Buffer(string).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
+  return Buffer.from(string).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
 }
 
 const hexDecode = (hex) => Buffer.from(hex, 'hex')
 
 const sign = (salt, target, secret) => {
-  const hmac = crypto.createHmac('sha256', hexDecode(secret))
+  const hmac = createHmac('sha256', hexDecode(secret))
   hmac.update(hexDecode(salt))
   hmac.update(target)
   return urlSafeBase64(hmac.digest())


### PR DESCRIPTION
Using `const createHmac = require('create-hmac')` will ensure that this script will work both on Node.js and Browser (otherwise it will crash on browser).
I've also updated `new Buffer` on line 7, which is deprecated in flavor of `Buffer.from`