### PR TITLE
Implement Max Bytes Filter

### DIFF
--- a/docs/generating_the_url_advanced.md
+++ b/docs/generating_the_url_advanced.md
@@ -169,6 +169,19 @@ Redefines quality of the resulting image, percentage.
 
 Default: value from the environment variable.
 
+#### Max Bytes
+
+```
+max_bytes:%max_bytes
+mb:%max_bytes
+```
+
+This filter automatically degrades the quality of the image until the image is under the specified amount of bytes.
+
+*Warning: this filter processes image multiple times to achieve specified image size*
+
+Default: 0
+
 #### Background
 
 ```

--- a/process.go
+++ b/process.go
@@ -133,6 +133,15 @@ func canScaleOnLoad(imgtype imageType, scale float64) bool {
 	return imgtype == imageTypeJPEG || imgtype == imageTypeWEBP
 }
 
+func canFitToBytes(imgtype imageType) bool {
+	switch imgtype {
+	case imageTypeJPEG, imageTypeWEBP, imageTypeHEIC, imageTypeTIFF:
+		return true
+	default:
+		return false
+	}
+}
+
 func calcJpegShink(scale float64, imgtype imageType) int {
 	shrink := int(1.0 / scale)
 
@@ -683,4 +692,59 @@ func processImage(ctx context.Context) ([]byte, context.CancelFunc, error) {
 	}
 
 	return img.Save(po.Format, po.Quality)
+}
+
+func processImageMaxBytes(ctx context.Context) ([]byte, context.CancelFunc, error) {
+	initialResult, initialCancel, err := processImage(ctx)
+	if err != nil {
+		return initialResult, initialCancel, err
+	}
+
+	po := getProcessingOptions(ctx)
+	if canFitToBytes(po.Format) || len(initialResult) < po.MaxBytes {
+		return initialResult, initialCancel, nil
+	}
+
+	checkTimeout(ctx)
+
+	initialQuality := po.Quality
+
+	quality := initialQuality
+	result := initialResult
+	var cancel context.CancelFunc
+	var cancels []context.CancelFunc
+	cancelFunc := func() {
+		for _, cancel := range cancels {
+			cancel()
+		}
+	}
+
+	for len(result) > po.MaxBytes {
+		var diff float64
+		delta := float64(len(result)) / float64(po.MaxBytes)
+		switch {
+		case delta > 3:
+			diff = 0.25
+		case delta > 1.5:
+			diff = 0.5
+		default:
+			diff = 0.75
+		}
+		quality = int(float64(quality) * diff)
+
+		if quality < 10 {
+			return initialResult, initialCancel, nil
+		}
+
+		checkTimeout(ctx)
+
+		po.Quality = quality
+		result, cancel, err = processImage(ctx)
+		cancels = append(cancels, cancel)
+		if err != nil {
+			return result, cancelFunc, err
+		}
+	}
+
+	return result, cancelFunc, nil
 }

--- a/processing_handler.go
+++ b/processing_handler.go
@@ -148,14 +148,7 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 
 	checkTimeout(ctx)
 
-	po := getProcessingOptions(ctx)
-	var imageData []byte
-	var processcancel context.CancelFunc
-	if po.MaxBytes > 0 {
-		imageData, processcancel, err = processImageMaxBytes(ctx)
-	} else {
-		imageData, processcancel, err = processImage(ctx)
-	}
+	imageData, processcancel, err := processImage(ctx)
 	defer processcancel()
 	if err != nil {
 		if newRelicEnabled {

--- a/processing_handler.go
+++ b/processing_handler.go
@@ -148,7 +148,14 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 
 	checkTimeout(ctx)
 
-	imageData, processcancel, err := processImage(ctx)
+	po := getProcessingOptions(ctx)
+	var imageData []byte
+	var processcancel context.CancelFunc
+	if po.MaxBytes > 0 {
+		imageData, processcancel, err = processImageMaxBytes(ctx)
+	} else {
+		imageData, processcancel, err = processImage(ctx)
+	}
 	defer processcancel()
 	if err != nil {
 		if newRelicEnabled {

--- a/processing_options.go
+++ b/processing_options.go
@@ -116,6 +116,7 @@ type processingOptions struct {
 	Crop         cropOptions
 	Format       imageType
 	Quality      int
+	MaxBytes     int
 	Flatten      bool
 	Background   rgbColor
 	Blur         float32
@@ -193,6 +194,7 @@ func newProcessingOptions() *processingOptions {
 			Gravity:      gravityOptions{Type: gravityCenter},
 			Enlarge:      false,
 			Quality:      conf.Quality,
+			MaxBytes:     0,
 			Format:       imageTypeUnknown,
 			Background:   rgbColor{255, 255, 255},
 			Blur:         0,
@@ -542,6 +544,20 @@ func applyQualityOption(po *processingOptions, args []string) error {
 	return nil
 }
 
+func applyMaxBytesOption(po *processingOptions, args []string) error {
+	if len(args) > 1 {
+		return fmt.Errorf("Invalid max_bytes arguments: %v", args)
+	}
+
+	if max, err := strconv.Atoi(args[0]); err == nil && max > 0 {
+		po.MaxBytes = max
+	} else {
+		return fmt.Errorf("Invalid max_bytes: %s", args[0])
+	}
+
+	return nil
+}
+
 func applyBackgroundOption(po *processingOptions, args []string) error {
 	switch len(args) {
 	case 1:
@@ -744,6 +760,8 @@ func applyProcessingOption(po *processingOptions, name string, args []string) er
 		return applyCropOption(po, args)
 	case "quality", "q":
 		return applyQualityOption(po, args)
+	case "max_bytes", "mb":
+		return applyMaxBytesOption(po, args)
 	case "background", "bg":
 		return applyBackgroundOption(po, args)
 	case "blur", "bl":

--- a/processing_options.go
+++ b/processing_options.go
@@ -549,7 +549,7 @@ func applyMaxBytesOption(po *processingOptions, args []string) error {
 		return fmt.Errorf("Invalid max_bytes arguments: %v", args)
 	}
 
-	if max, err := strconv.Atoi(args[0]); err == nil && max > 0 {
+	if max, err := strconv.Atoi(args[0]); err == nil && max >= 0 {
 		po.MaxBytes = max
 	} else {
 		return fmt.Errorf("Invalid max_bytes: %s", args[0])


### PR DESCRIPTION
In some cases I needed to get image with size less than specified (e.g to pass some custom RSS feeds specifications).

#### Max Bytes

```
max_bytes:%max_bytes
mb:%max_bytes
```

This filter automatically degrades the quality of the image until the image is under the specified amount of bytes.

*Warning: this filter processes image multiple times to achieve specified image size*

Default: 0