### PR TITLE
Add Homebrew package to installation methods

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,6 +39,13 @@ git push heroku master
 
 [imgproxy](https://aur.archlinux.org/packages/imgproxy/) package is available from AUR.
 
+### macOS + Homebrew
+
+[imgproxy](https://formulae.brew.sh/formula/imgproxy) is available from Homebrew:
+```bash
+brew install imgproxy
+```
+
 ## From the source
 
 ### Ubuntu


### PR DESCRIPTION
`imgproxy` formula has been merged into Homebrew: https://github.com/Homebrew/homebrew-core/pull/47489

This will make this easier for development environments on macOS when not using docker, as you no longer need to have `go` installed, and upgrades will be managed by `brew`.