### PR TITLE
Generating secrets for Heroku automatically

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,12 +9,12 @@
   "env": {
     "IMGPROXY_KEY": {
       "description": "Hex-encoded secret key for signing URLs.",
-      "value": "",
+      "generator": "secret",
       "required": false
     },
     "IMGPROXY_SALT": {
       "description": "Hex-encoded secret salt for signing URLs.",
-      "value": "",
+      "generator": "secret",
       "required": false
     }
   }


### PR DESCRIPTION
Your deploy to heroku wasn't using the `generator: secret`. I added that to app.json, and it now does deploy automatically with the secrets filled in.