### PR TITLE
Basic support for PDF

### DIFF
--- a/image_type.go
+++ b/image_type.go
@@ -26,6 +26,7 @@ const (
 	imageTypeHEIC    = imageType(C.HEIC)
 	imageTypeBMP     = imageType(C.BMP)
 	imageTypeTIFF    = imageType(C.TIFF)
+	imageTypePDF     = imageType(C.PDF)
 
 	contentDispositionFilenameFallback = "image"
 )
@@ -42,6 +43,7 @@ var (
 		"heic": imageTypeHEIC,
 		"bmp":  imageTypeBMP,
 		"tiff": imageTypeTIFF,
+		"pdf":  imageTypePDF,
 	}
 
 	mimes = map[imageType]string{
@@ -54,6 +56,7 @@ var (
 		imageTypeHEIC: "image/heif",
 		imageTypeBMP:  "image/bmp",
 		imageTypeTIFF: "image/tiff",
+		imageTypePDF:  "application/pdf",
 	}
 
 	contentDispositionsFmt = map[imageType]string{
@@ -66,6 +69,7 @@ var (
 		imageTypeHEIC: "inline; filename=\"%s.heic\"",
 		imageTypeBMP:  "inline; filename=\"%s.bmp\"",
 		imageTypeTIFF: "inline; filename=\"%s.tiff\"",
+		imageTypePDF:  "inline; filename=\"%s.pdf\"",
 	}
 )
 

--- a/imagemeta/pdf.go
+++ b/imagemeta/pdf.go
@@ -1,0 +1,38 @@
+package imagemeta
+
+import (
+	"bytes"
+	"io"
+)
+
+var pdfMagick = []byte("%PDF-")
+
+type PdfFormatError string
+
+func (e PdfFormatError) Error() string { return "invalid PDF format: " + string(e) }
+
+func DecodePdfMeta(r io.Reader) (Meta, error) {
+	var tmp [16]byte
+
+	if _, err := io.ReadFull(r, tmp[:5]); err != nil {
+		return nil, err
+	}
+
+	if !bytes.Equal(pdfMagick, tmp[:5]) {
+		return nil, PdfFormatError("not a PDF image")
+	}
+
+	if _, err := io.ReadFull(r, tmp[:]); err != nil {
+		return nil, err
+	}
+
+	return &meta{
+		format: "pdf",
+		width:  1,
+		height: 1,
+	}, nil
+}
+
+func init() {
+	RegisterFormat(string(pdfMagick), DecodePdfMeta)
+}

--- a/vips.c
+++ b/vips.c
@@ -16,6 +16,9 @@
 #define VIPS_SUPPORT_TIFF \
   (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 6))
 
+#define VIPS_SUPPORT_PDF \
+  (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 6))
+
 #define VIPS_SUPPORT_MAGICK \
   (VIPS_MAJOR_VERSION > 8 || (VIPS_MAJOR_VERSION == 8 && VIPS_MINOR_VERSION >= 7))
 
@@ -89,6 +92,8 @@ vips_type_find_load_go(int imgtype) {
     return vips_type_find("VipsOperation", "magickload_buffer");
   case (TIFF):
     return vips_type_find("VipsOperation", "tiffload_buffer");
+  case (PDF):
+    return vips_type_find("VipsOperation", "pdfload_buffer");
   }
   return 0;
 }
@@ -192,6 +197,16 @@ vips_tiffload_go(void *buf, size_t len, VipsImage **out) {
   return vips_tiffload_buffer(buf, len, out, "access", VIPS_ACCESS_SEQUENTIAL, NULL);
 #else
   vips_error("vips_tiffload_go", "Loading TIFF is not supported (libvips 8.6+ reuired)");
+  return 1;
+#endif
+}
+
+int
+vips_pdfload_go(void *buf, size_t len, VipsImage **out) {
+#if VIPS_SUPPORT_PDF
+  return vips_pdfload_buffer(buf, len, out, "access", VIPS_ACCESS_SEQUENTIAL, NULL);
+#else
+  vips_error("vips_pdfload_go", "Loading PDF is not supported.");
   return 1;
 #endif
 }
@@ -603,6 +618,12 @@ vips_tiffsave_go(VipsImage *in, void **buf, size_t *len, int quality) {
   vips_error("vips_tiffsave_go", "Saving TIFF is not supported (libvips 8.6+ reuired)");
   return 1;
 #endif
+}
+
+int
+vips_pdfsave_go(VipsImage *in, void **buf, size_t *len, int quality) {
+  vips_error("vips_pdfsave_go", "Saving pdf is not supported");
+  return 1;
 }
 
 int

--- a/vips.go
+++ b/vips.go
@@ -171,6 +171,8 @@ func (img *vipsImage) Load(data []byte, imgtype imageType, shrink int, scale flo
 		err = C.vips_bmpload_go(unsafe.Pointer(&data[0]), C.size_t(len(data)), &tmp)
 	case imageTypeTIFF:
 		err = C.vips_tiffload_go(unsafe.Pointer(&data[0]), C.size_t(len(data)), &tmp)
+	case imageTypePDF:
+		err = C.vips_pdfload_go(unsafe.Pointer(&data[0]), C.size_t(len(data)), &tmp)
 	}
 	if err != 0 {
 		return vipsError()
@@ -207,6 +209,8 @@ func (img *vipsImage) Save(imgtype imageType, quality int, stripMeta bool) ([]by
 		err = C.vips_bmpsave_go(img.VipsImage, &ptr, &imgsize)
 	case imageTypeTIFF:
 		err = C.vips_tiffsave_go(img.VipsImage, &ptr, &imgsize, C.int(quality))
+	case imageTypePDF:
+		err = C.vips_pdfsave_go(img.VipsImage, &ptr, &imgsize, C.int(quality))
 	}
 	if err != 0 {
 		C.g_free_go(&ptr)

--- a/vips.h
+++ b/vips.h
@@ -14,7 +14,8 @@ enum ImgproxyImageTypes {
   SVG,
   HEIC,
   BMP,
-  TIFF
+  TIFF,
+  PDF
 };
 
 int vips_initialize();
@@ -35,6 +36,7 @@ int vips_svgload_go(void *buf, size_t len, double scale, VipsImage **out);
 int vips_heifload_go(void *buf, size_t len, VipsImage **out);
 int vips_bmpload_go(void *buf, size_t len, VipsImage **out);
 int vips_tiffload_go(void *buf, size_t len, VipsImage **out);
+int vips_pdfload_go(void *buf, size_t len, VipsImage **out);
 
 int vips_get_orientation(VipsImage *image);
 void vips_strip_meta(VipsImage *image);
@@ -91,5 +93,6 @@ int vips_gifsave_go(VipsImage *in, void **buf, size_t *len);
 int vips_icosave_go(VipsImage *in, void **buf, size_t *len);
 int vips_bmpsave_go(VipsImage *in, void **buf, size_t *len);
 int vips_tiffsave_go(VipsImage *in, void **buf, size_t *len, int quality);
+int vips_pdfsave_go(VipsImage *in, void **buf, size_t *len, int quality);
 
 void vips_cleanup();


### PR DESCRIPTION
Libvips has support for PDF when PDFium or Poppler are availble.

I've tried this patch and imgproxy is able to handle pdfs.

However, I'm not sure how to expose to the user of Imgproxy the possibility of choosing a page from the pdf, or an scale or dpi.

It can be done by changing vips.c and passing the additional parameters documented [here](https://github.com/libvips/libvips/blob/df72de89d0835e701b2903e68bc369f4a6676bf7/libvips/foreign/pdfload.c#L902). 

```
  return vips_pdfload_buffer(buf, len, out, "access", VIPS_ACCESS_SEQUENTIAL, "page", 4, "scale", 4.0, "dpi", 400.0, NULL);
```

but, as I said, I'm not sure how this could be exposed to the user in the url.

Thanks for imgproxy!