### PR TITLE
Config option to disable autorotation

### DIFF
--- a/config.go
+++ b/config.go
@@ -182,7 +182,7 @@ type config struct {
 	Quality               int
 	GZipCompression       int
 	StripMetadata         bool
-
+	AutoRotate            bool
 	EnableWebpDetection bool
 	EnforceWebp         bool
 	EnableClientHints   bool
@@ -266,6 +266,7 @@ var conf = config{
 	PngQuantizationColors:          256,
 	Quality:                        80,
 	StripMetadata:                  true,
+	AutoRotate:                     true,
 	UserAgent:                      fmt.Sprintf("imgproxy/%s", version),
 	Presets:                        make(presets),
 	WatermarkOpacity:               1,
@@ -324,6 +325,7 @@ func configure() error {
 	intEnvConfig(&conf.Quality, "IMGPROXY_QUALITY")
 	intEnvConfig(&conf.GZipCompression, "IMGPROXY_GZIP_COMPRESSION")
 	boolEnvConfig(&conf.StripMetadata, "IMGPROXY_STRIP_METADATA")
+	boolEnvConfig(&conf.AutoRotate, "IMGPROXY_AUTO_ROTATE")
 
 	boolEnvConfig(&conf.EnableWebpDetection, "IMGPROXY_ENABLE_WEBP_DETECTION")
 	boolEnvConfig(&conf.EnforceWebp, "IMGPROXY_ENFORCE_WEBP")

--- a/config.go
+++ b/config.go
@@ -183,6 +183,7 @@ type config struct {
 	GZipCompression       int
 	StripMetadata         bool
 	AutoRotate            bool
+	
 	EnableWebpDetection bool
 	EnforceWebp         bool
 	EnableClientHints   bool

--- a/config.go
+++ b/config.go
@@ -183,7 +183,7 @@ type config struct {
 	GZipCompression       int
 	StripMetadata         bool
 	AutoRotate            bool
-	
+
 	EnableWebpDetection bool
 	EnforceWebp         bool
 	EnableClientHints   bool

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -297,3 +297,4 @@ imgproxy can send logs to syslog, but this feature is disabled by default. To en
 * `IMGPROXY_USE_LINEAR_COLORSPACE`: when `true`, imgproxy will process images in linear colorspace. This will slow down processing. Note that images won't be fully processed in linear colorspace while shrink-on-load is enabled (see below).
 * `IMGPROXY_DISABLE_SHRINK_ON_LOAD`: when `true`, disables shrink-on-load for JPEG and WebP. Allows to process the whole image in linear colorspace but dramatically slows down resizing and increases memory usage when working with large images.
 * `IMGPROXY_STRIP_METADATA`: whether to strip all metadata (EXIF, IPTC, etc.) from JPEG and WebP output images. Default: `true`.
+* `IMGPROXY_AUTO_ROTATE`: whether to auto rotate images based on the EXIF Orientation parameter (if available in the image meta data). Default: `true`.

--- a/docs/generating_the_url_advanced.md
+++ b/docs/generating_the_url_advanced.md
@@ -451,8 +451,8 @@ Default: `false`
 #### Auto Rotate
 
 ```
-auto_rotate:%strip_metadata
-ar:%strip_metadata
+auto_rotate:%auto_rotate
+ar:%auto_rotate
 ```
 
 When set to `1`, `t` or `true`, imgproxy will automatically rotate images based onon the EXIF Orientation parameter (if available in the image meta data). Normally this is controlled by the [IMGPROXY_AUTO_ROTATE](configuration.md#miscellaneous) configuration but this procesing option allows the configuration to be set for each request.

--- a/docs/generating_the_url_advanced.md
+++ b/docs/generating_the_url_advanced.md
@@ -448,6 +448,17 @@ When set to `1`, `t` or `true`, imgproxy will strip the metadata (EXIF, IPTC, et
 
 Default: `false`
 
+#### Auto Rotate
+
+```
+auto_rotate:%strip_metadata
+ar:%strip_metadata
+```
+
+When set to `1`, `t` or `true`, imgproxy will automatically rotate images based onon the EXIF Orientation parameter (if available in the image meta data). Normally this is controlled by the [IMGPROXY_AUTO_ROTATE](configuration.md#miscellaneous) configuration but this procesing option allows the configuration to be set for each request.
+
+Default: `true`
+
 #### Filename
 
 ```

--- a/process.go
+++ b/process.go
@@ -394,7 +394,7 @@ func transformImage(ctx context.Context, img *vipsImage, data []byte, po *proces
 
 	checkTimeout(ctx)
 
-	if angle != vipsAngleD0 {
+	if angle != vipsAngleD0 && po.AutoRotate {
 		if err = img.Rotate(angle); err != nil {
 			return err
 		}

--- a/processing_options.go
+++ b/processing_options.go
@@ -144,6 +144,7 @@ type processingOptions struct {
 	Blur          float32
 	Sharpen       float32
 	StripMetadata bool
+	AutoRotate    bool
 
 	CacheBuster string
 
@@ -229,6 +230,7 @@ func newProcessingOptions() *processingOptions {
 			Dpr:           1,
 			Watermark:     watermarkOptions{Opacity: 1, Replicate: false, Gravity: gravityOptions{Type: gravityCenter}},
 			StripMetadata: conf.StripMetadata,
+			AutoRotate:    conf.AutoRotate,
 		}
 	})
 
@@ -858,6 +860,14 @@ func applyStripMetadataOption(po *processingOptions, args []string) error {
 	return nil
 }
 
+func applyAutoRotateOption(po *processingOptions, args []string) error {
+	if len(args[0]) > 0 {
+		po.AutoRotate = parseBoolOption(args[0])
+	}
+
+	return nil
+}
+
 func applyProcessingOption(po *processingOptions, name string, args []string) error {
 	switch name {
 	case "format", "f", "ext":
@@ -904,6 +914,8 @@ func applyProcessingOption(po *processingOptions, name string, args []string) er
 		return applyCacheBusterOption(po, args)
 	case "strip_metadata", "sm":
 		return applyStripMetadataOption(po, args)
+	case "auto_rotate", "ar":
+		return applyAutoRotateOption(po, args)		
 	case "filename", "fn":
 		return applyFilenameOption(po, args)
 	}

--- a/processing_options.go
+++ b/processing_options.go
@@ -915,7 +915,7 @@ func applyProcessingOption(po *processingOptions, name string, args []string) er
 	case "strip_metadata", "sm":
 		return applyStripMetadataOption(po, args)
 	case "auto_rotate", "ar":
-		return applyAutoRotateOption(po, args)		
+		return applyAutoRotateOption(po, args)
 	case "filename", "fn":
 		return applyFilenameOption(po, args)
 	}

--- a/processing_options_test.go
+++ b/processing_options_test.go
@@ -414,6 +414,38 @@ func (s *ProcessingOptionsTestSuite) TestParsePathAdvancedStripMetadata() {
 	assert.True(s.T(), po.StripMetadata)
 }
 
+func (s *ProcessingOptionsTestSuite) TestParsePathAdvancedAutoRotateDeault() {
+	req := s.getRequest("/unsafe/strip_metadata:true/plain/http://images.dev/lorem/ipsum.jpg")
+	ctx, err := parsePath(context.Background(), req)
+
+	require.Nil(s.T(), err)
+
+	po := getProcessingOptions(ctx)
+	assert.True(s.T(), po.AutoRotate)
+}
+
+func (s *ProcessingOptionsTestSuite) TestParsePathAdvancedAutoRotateFalse() {
+	req := s.getRequest("/unsafe/auto_rotate:false/plain/http://images.dev/lorem/ipsum.jpg")
+	ctx, err := parsePath(context.Background(), req)
+
+	require.Nil(s.T(), err)
+
+	po := getProcessingOptions(ctx)
+	assert.False(s.T(), po.AutoRotate)
+}
+
+func (s *ProcessingOptionsTestSuite) TestParsePathAdvancedAutoRotateTrue() {
+	req := s.getRequest("/unsafe/auto_rotate:true/plain/http://images.dev/lorem/ipsum.jpg")
+	ctx, err := parsePath(context.Background(), req)
+
+	require.Nil(s.T(), err)
+
+	po := getProcessingOptions(ctx)
+	assert.True(s.T(), po.AutoRotate)
+}
+
+
+
 func (s *ProcessingOptionsTestSuite) TestParsePathWebpDetection() {
 	conf.EnableWebpDetection = true
 

--- a/processing_options_test.go
+++ b/processing_options_test.go
@@ -444,8 +444,6 @@ func (s *ProcessingOptionsTestSuite) TestParsePathAdvancedAutoRotateTrue() {
 	assert.True(s.T(), po.AutoRotate)
 }
 
-
-
 func (s *ProcessingOptionsTestSuite) TestParsePathWebpDetection() {
 	conf.EnableWebpDetection = true
 


### PR DESCRIPTION
In issue #160 @DarthSim suggested:
_Well, maybe it makes sense to add a config option to disable autorotation. If you have more images with incorrect exif-ifd0-Orientation than with correct ones, the option will help you a little._

This PR implements the config option **auto_rotate**, which is **true** by default. 

I followed the existing config conventions. So you can specify it both via the environment variable **IMGPROXY_AUTO_ROTATE**, and via the **auto_rotate** (or **ar** shortcut) option in an advanced URL.\

It is useful in our setup because we, unfortunately, got a lot of images with incorrect EXIF orientation meta info.
 