### PR TITLE
Automatically publish GitHub releases on tag push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,19 @@ workflows:
           go_version: "1.12"
           vips_version: "8.7"
 
+  release:
+    jobs:
+      - checkout_code:
+          filters: &release_tags_filter
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v\d+\.\d+\.\d+.*/
+      - publish_github_release:
+          requires:
+            - checkout_code # to grab changes from CHANGELOG
+          filters: *release_tags_filter
+
 executors:
   imgproxy:
     docker:
@@ -157,3 +170,30 @@ jobs:
           key: go-modules-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
+
+  publish_github_release:
+    executor: imgproxy
+    steps:
+      - attach_workspace:
+          at: .
+      - install_go:
+          go_version: "1.14"
+      - run:
+          name: Install github-release tool
+          command: go get github.com/github-release/github-release
+      - run:
+          name: Upload GitHub release
+          command: |
+            # Extract changelog entries between this and previous version headers
+            escaped_version=$(echo ${CIRCLE_TAG#v} | sed -e 's/[]\/$*.^[]/\\&/g')
+            description_body=$(awk "BEGIN{inrelease=0} /## \[${escaped_version}\]/{inrelease=1;next} /## \[[0-9]+\.[0-9]+\.[0-9]+\]/{inrelease=0;exit} {if (inrelease) print}" CHANGELOG.md)
+            # Add pre-release option if tag name has any suffix after vMAJOR.MINOR.PATCH
+            [[ ${CIRCLE_TAG} =~ ^v[0-9]+\.[0-9]+\.[0-9]+.+ ]] && prerelease="--pre-release"
+            # Create release!
+            github-release release \
+              --user ${CIRCLE_PROJECT_USERNAME} \
+              --repo ${CIRCLE_PROJECT_REPONAME} \
+              --tag ${CIRCLE_TAG} \
+              --name ${CIRCLE_TAG} \
+              --description "${description_body}" \
+              $prerelease


### PR DESCRIPTION
Runs separate workflow only on tag pushes to publish release.

What it does:
 1. Extracts current release changes from CHANGELOG.md (everything between `## [${CIRCLE_TAG#v}]` and next version header in file)
 2. Determines whether this is pre-release by checking whether there is any prefix in tag name (so 2.16.0 is a release, but 2.16.0-preview125 is a pre-release)
 3. Calls [github-release](https://github.com/github-release/github-release) tool to make the release itself.

How to set up:
 1. Generate new [personal access token](https://github.com/settings/tokens) with `public_repo` scope and write it to CircleCI [project settings' Environment variables](https://app.circleci.com/settings/project/github/imgproxy/imgproxy/environment-variables) section as `GITHUB_TOKEN`.
 2. Merge this PR
 3. Push version tags as usual

Examples:
 - Pre-release: https://github.com/Envek/imgproxy/releases/tag/v2.16.0-epsilon
 - Release: https://github.com/Envek/imgproxy/releases/tag/v2.16.0