### PR TITLE
Crop by aspect ratio

### DIFF
--- a/docs/generating_the_url_advanced.md
+++ b/docs/generating_the_url_advanced.md
@@ -170,6 +170,18 @@ Defines an area of the image to be processed (crop before resize).
 * `width` and `height` define the size of the area. When `width` or `height` is set to `0`, imgproxy will use the full width/height of the source image.
 * `gravity` _(optional)_ accepts the same values as [gravity](#gravity) option. When `gravity` is not set, imgproxy will use the value of the [gravity](#gravity) option.
 
+### Aspect ratio
+
+```
+aspect_ratio:%width:%height:%gravity
+ar:%width:%height:%gravity
+```
+
+Defines an area of the image to be processed (aspect ratio before resize).
+
+* `width` and `height` define the aspect ratio of the area. When `width` or `height` is set to `0`, imgproxy will use the [crop](#crop) option.
+* `gravity` _(optional)_ accepts the same values as [gravity](#gravity) option. When `gravity` is not set, imgproxy will use the value of the [gravity](#gravity) option.
+
 #### Padding
 
 ```

--- a/process.go
+++ b/process.go
@@ -322,9 +322,28 @@ func transformImage(ctx context.Context, img *vipsImage, data []byte, po *proces
 	}
 
 	srcWidth, srcHeight, angle, flip := extractMeta(img)
-	cropWidth, cropHeight := po.Crop.Width, po.Crop.Height
 
-	cropGravity := po.Crop.Gravity
+	var cropWidth, cropHeight int
+	var cropGravity gravityOptions
+
+	if po.AspectRatio.Width > 0 && po.AspectRatio.Height > 0 {
+		ar := float64(po.AspectRatio.Width) / float64(po.AspectRatio.Height)
+		var w, h float64
+		if ar < 1 {
+			w = math.Min(float64(srcHeight)*ar, float64(srcWidth))
+			h = w / ar
+		} else {
+			h = math.Min(float64(srcWidth)/ar, float64(srcHeight))
+			w = h * ar
+		}
+		cropWidth = int(math.Round(w))
+		cropHeight = int(math.Round(h))
+		cropGravity = po.AspectRatio.Gravity
+	} else {
+		cropWidth, cropHeight = po.Crop.Width, po.Crop.Height
+		cropGravity = po.Crop.Gravity
+	}
+
 	if cropGravity.Type == gravityUnknown {
 		cropGravity = po.Gravity
 	}

--- a/processing_options.go
+++ b/processing_options.go
@@ -100,6 +100,12 @@ type cropOptions struct {
 	Gravity gravityOptions
 }
 
+type aspectRatioOptions struct {
+	Width   int
+	Height  int
+	Gravity gravityOptions
+}
+
 type paddingOptions struct {
 	Enabled bool
 	Top     int
@@ -133,6 +139,7 @@ type processingOptions struct {
 	Gravity       gravityOptions
 	Enlarge       bool
 	Extend        extendOptions
+	AspectRatio   aspectRatioOptions
 	Crop          cropOptions
 	Padding       paddingOptions
 	Trim          trimOptions
@@ -546,6 +553,28 @@ func applyGravityOption(po *processingOptions, args []string) error {
 	return parseGravity(&po.Gravity, args)
 }
 
+func applyAspectRatioOption(po *processingOptions, args []string) error {
+	if len(args) > 5 {
+		return fmt.Errorf("Invalid aspect ratio arguments: %v", args)
+	}
+
+	if err := parseDimension(&po.AspectRatio.Width, "aspect ratio width", args[0]); err != nil {
+		return err
+	}
+
+	if len(args) > 1 {
+		if err := parseDimension(&po.AspectRatio.Height, "aspect ratio height", args[1]); err != nil {
+			return err
+		}
+	}
+
+	if len(args) > 2 {
+		return parseGravity(&po.AspectRatio.Gravity, args[2:])
+	}
+
+	return nil
+}
+
 func applyCropOption(po *processingOptions, args []string) error {
 	if len(args) > 5 {
 		return fmt.Errorf("Invalid crop arguments: %v", args)
@@ -882,6 +911,8 @@ func applyProcessingOption(po *processingOptions, name string, args []string) er
 		return applyDprOption(po, args)
 	case "gravity", "g":
 		return applyGravityOption(po, args)
+	case "aspect_ratio", "ar":
+		return applyAspectRatioOption(po, args)
 	case "crop", "c":
 		return applyCropOption(po, args)
 	case "trim", "t":

--- a/processing_options_test.go
+++ b/processing_options_test.go
@@ -322,6 +322,19 @@ func (s *ProcessingOptionsTestSuite) TestParsePathAdvancedDpr() {
 	po := getProcessingOptions(ctx)
 	assert.Equal(s.T(), 2.0, po.Dpr)
 }
+
+func (s *ProcessingOptionsTestSuite) TestParsePathAdvancedAspectRatio() {
+	req := s.getRequest("/unsafe/ar:3:4:ce/plain/http://images.dev/lorem/ipsum.jpg")
+	ctx, err := parsePath(context.Background(), req)
+
+	require.Nil(s.T(), err)
+
+	po := getProcessingOptions(ctx)
+	assert.Equal(s.T(), 3, po.AspectRatio.Width)
+	assert.Equal(s.T(), 4, po.AspectRatio.Height)
+	assert.Equal(s.T(), gravityCenter, po.AspectRatio.Gravity.Type)
+}
+
 func (s *ProcessingOptionsTestSuite) TestParsePathAdvancedWatermark() {
 	req := s.getRequest("/unsafe/watermark:0.5:soea:10:20:0.6/plain/http://images.dev/lorem/ipsum.jpg")
 	ctx, err := parsePath(context.Background(), req)


### PR DESCRIPTION
We want to switch [ngx_http_imgproc](https://github.com/tommiv/ngx_http_imgproc) to imgproxy. Does imgproxy not support crop by aspect ratio? 

This PR implements crop by aspect ratio.