### PR TITLE
optionally exclude preset from signature

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,14 @@
+steps:
+- id: 'Build: Docker Image'
+  name: gcr.io/cloud-builders/docker
+  args:
+  - build
+  - -f
+  - docker/Dockerfile
+  - -t
+  - us.gcr.io/$PROJECT_ID/dashboard:$BRANCH_NAME$TAG_NAME
+  - .
+
+# Push docker images to container registry
+images:
+- us.gcr.io/$PROJECT_ID/dashboard:$BRANCH_NAME$TAG_NAME

--- a/config.go
+++ b/config.go
@@ -239,8 +239,10 @@ type config struct {
 
 	BaseURL string
 
-	Presets     presets
-	OnlyPresets bool
+	Presets                     presets
+	OnlyPresets                 bool
+	// ExcludePresetsFromSignature is only taken into account when OnlyPresets is true
+	ExcludePresetsFromSignature bool
 
 	WatermarkData    string
 	WatermarkPath    string
@@ -408,6 +410,7 @@ func configure() error {
 		return err
 	}
 	boolEnvConfig(&conf.OnlyPresets, "IMGPROXY_ONLY_PRESETS")
+	boolEnvConfig(&conf.ExcludePresetsFromSignature, "IMGPROXY_EXCLUDE_PRESETS_FROM_SIGNATURE")
 
 	strEnvConfig(&conf.WatermarkData, "IMGPROXY_WATERMARK_DATA")
 	strEnvConfig(&conf.WatermarkPath, "IMGPROXY_WATERMARK_PATH")

--- a/config.go
+++ b/config.go
@@ -239,8 +239,8 @@ type config struct {
 
 	BaseURL string
 
-	Presets                     presets
-	OnlyPresets                 bool
+	Presets     presets
+	OnlyPresets bool
 	// ExcludePresetsFromSignature is only taken into account when OnlyPresets is true
 	ExcludePresetsFromSignature bool
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -30,4 +30,9 @@ Setting `IMGPROXY_ONLY_PRESETS` as `true` switches imgproxy into "presets-only m
 http://imgproxy.example.com/unsafe/thumbnail:blurry:watermarked/plain/http://example.com/images/curiosity.jpg@png
 ```
 
-All othe URL formats are disabled in this mode.
+All other URL formats are disabled in this mode.
+
+## Exclude presets from URL signature validation
+
+Setting `IMGPROXY_EXCLUDE_PRESETS_FROM_SIGNATURE` as `true` excludes the presets segment of the URL path from signature validation. Note that this only works when `IMGPROXY_ONLY_PRESETS` is set to `true`. Thus, you can use a single digitally signed URL for fetching multiple pre-defined formats of the same image URL.
+

--- a/processing_options.go
+++ b/processing_options.go
@@ -1106,7 +1106,7 @@ func parsePath(ctx context.Context, r *http.Request) (context.Context, error) {
 	}
 
 	if !conf.AllowInsecure {
-		if err = validatePath(parts[0], strings.TrimPrefix(path, parts[0])); err != nil {
+		if err = validatePath(parts[0], extractPathSegmentToValidate(path, parts)); err != nil {
 			return ctx, newError(403, err.Error(), msgForbidden)
 		}
 	}
@@ -1141,6 +1141,15 @@ func parsePath(ctx context.Context, r *http.Request) (context.Context, error) {
 	ctx = context.WithValue(ctx, processingOptionsCtxKey, po)
 
 	return ctx, nil
+}
+
+func extractPathSegmentToValidate(path string, pathSegments []string) string {
+	pathToValidate := strings.TrimPrefix(path, pathSegments[0])
+	if conf.OnlyPresets && conf.ExcludePresetsFromSignature {
+		pathToValidate = strings.TrimPrefix(pathToValidate, "/")
+		pathToValidate = strings.TrimPrefix(pathToValidate, pathSegments[1])
+	}
+	return pathToValidate
 }
 
 func getImageURL(ctx context.Context) string {

--- a/processing_options_test.go
+++ b/processing_options_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -603,6 +604,17 @@ func (s *ProcessingOptionsTestSuite) TestParseBase64URLOnlyPresets() {
 	assert.Equal(s.T(), float32(0.2), po.Blur)
 	assert.Equal(s.T(), 50, po.Quality)
 }
+
+func (s *ProcessingOptionsTestSuite) TestExtractPathSegmentToValidateWithPresetsOnly() {
+	conf.AllowInsecure = false
+	conf.OnlyPresets = true
+	path := "signature/test1:test2/plain/http://images.dev/lorem/ipsum.jpg"
+	parts := strings.Split(path, "/")
+	assert.Equal(s.T(), "/test1:test2/plain/http://images.dev/lorem/ipsum.jpg", extractPathSegmentToValidate(path, parts))
+	conf.ExcludePresetsFromSignature = true
+	assert.Equal(s.T(), "/plain/http://images.dev/lorem/ipsum.jpg", extractPathSegmentToValidate(path, parts))
+}
+
 func TestProcessingOptions(t *testing.T) {
 	suite.Run(t, new(ProcessingOptionsTestSuite))
 }


### PR DESCRIPTION
@DarthSim, I saw your response to my issue where I requested if we could exclude presets from the signature. While I understand your reasoning, I think I did not fully elaborate on our use case. So, we work with images in the public domain, so we are not really concerned with the full resolution images being accessed. What we are concerned with is the ability to send arbitrary requests to our server and overloading it (or a DOS/DDOS attack). On the other hand, we do need to get multiple formats for the same image in the browser and having to construct a signed URL server side for every case is cumbersome. So, this PR is a very narrow one with a very limited scope. Let me know if this makes sense?