### PR TITLE
Initialize buffer_size_bytes metric by exponential buckets

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -65,6 +65,7 @@ func initPrometheus() {
 		Namespace: conf.PrometheusNamespace,
 		Name:      "buffer_size_bytes",
 		Help:      "A histogram of the buffer size in bytes.",
+		Buckets:   prometheus.ExponentialBuckets(1024, 2, 14),
 	}, []string{"type"})
 
 	prometheusBufferDefaultSize = prometheus.NewGaugeVec(prometheus.GaugeOpts{


### PR DESCRIPTION
As buffer_size_bytes measured in bytes, default buckets from .005 to 10 are practically unsuitable for images.

I propose to initialize buffer_size_bytes by buckets with exponential growth from 1K to 8M. This is most likely not the best solution, but looking better than the current one.