### PR TITLE
Removes checking for mdat box before meta box.

### DIFF
--- a/imagemeta/heif.go
+++ b/imagemeta/heif.go
@@ -210,8 +210,6 @@ func heifReadBoxes(d *heifData, r io.Reader) error {
 			if w > d.Width || h > d.Height {
 				d.Width, d.Height = w, h
 			}
-		case "mdat":
-			return errors.New("mdat box occurred before meta box")
 		default:
 			if err := heifDiscardN(r, boxDataSize); err != nil {
 				return err


### PR DESCRIPTION
I have some heif files that have mdat boxes before meta boxes that decode fine in other places, including libvips. I'm curious why that state throws an error? My (fairly limited) understanding of the container format is that the order of boxes is not important.