### PR TITLE
Expires option

### DIFF
--- a/docs/generating_the_url.md
+++ b/docs/generating_the_url.md
@@ -530,6 +530,17 @@ Specifies the resulting image format. Alias for [extension](#extension) URL part
 
 Default: `jpg`
 
+### Expires
+
+```
+expires:%timestamp
+exp:%timestamp
+```
+
+When set, imgproxy will check provided timestamp and return 404 when expired.
+
+Default: empty
+
 ## Source URL
 
 There are two ways to specify source url:

--- a/docs/generating_the_url.md
+++ b/docs/generating_the_url.md
@@ -480,6 +480,17 @@ It's highly recommended to prefer `cachebuster` option over URL query string bec
 
 Default: empty
 
+### Expires
+
+```
+expires:%timestamp
+exp:%timestamp
+```
+
+When set, imgproxy will check provided unix timestamp and return 404 when expired.
+
+Default: empty
+
 ### Strip Metadata
 
 ```
@@ -529,17 +540,6 @@ ext:%extension
 Specifies the resulting image format. Alias for [extension](#extension) URL part.
 
 Default: `jpg`
-
-### Expires
-
-```
-expires:%timestamp
-exp:%timestamp
-```
-
-When set, imgproxy will check provided timestamp and return 404 when expired.
-
-Default: empty
 
 ## Source URL
 

--- a/processing_options_test.go
+++ b/processing_options_test.go
@@ -568,6 +568,24 @@ func (s *ProcessingOptionsTestSuite) TestParsePathOnlyPresets() {
 	assert.Equal(s.T(), 50, po.Quality)
 }
 
+func (s *ProcessingOptionsTestSuite) TestParseExpires() {
+	req := s.getRequest("/unsafe/exp:32503669200/plain/http://images.dev/lorem/ipsum.jpg")
+	ctx, err := parsePath(context.Background(), req)
+
+	require.Nil(s.T(), err)
+
+	po := getProcessingOptions(ctx)
+	assert.Equal(s.T(), int64(32503669200), po.Expires)
+}
+
+func (s *ProcessingOptionsTestSuite) TestParseExpiresExpired() {
+	req := s.getRequest("/unsafe/exp:1609448400/plain/http://images.dev/lorem/ipsum.jpg")
+	_, err := parsePath(context.Background(), req)
+
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), "Link expired", err.Error())
+}
+
 func (s *ProcessingOptionsTestSuite) TestParseBase64URLOnlyPresets() {
 	conf.OnlyPresets = true
 	conf.Presets["test1"] = urlOptions{

--- a/processing_options_test.go
+++ b/processing_options_test.go
@@ -570,12 +570,9 @@ func (s *ProcessingOptionsTestSuite) TestParsePathOnlyPresets() {
 
 func (s *ProcessingOptionsTestSuite) TestParseExpires() {
 	req := s.getRequest("/unsafe/exp:32503669200/plain/http://images.dev/lorem/ipsum.jpg")
-	ctx, err := parsePath(context.Background(), req)
+	_, err := parsePath(context.Background(), req)
 
 	require.Nil(s.T(), err)
-
-	po := getProcessingOptions(ctx)
-	assert.Equal(s.T(), int64(32503669200), po.Expires)
 }
 
 func (s *ProcessingOptionsTestSuite) TestParseExpiresExpired() {
@@ -583,7 +580,7 @@ func (s *ProcessingOptionsTestSuite) TestParseExpiresExpired() {
 	_, err := parsePath(context.Background(), req)
 
 	require.Error(s.T(), err)
-	assert.Equal(s.T(), "Link expired", err.Error())
+	assert.Equal(s.T(), msgExpiredURL, err.Error())
 }
 
 func (s *ProcessingOptionsTestSuite) TestParseBase64URLOnlyPresets() {


### PR DESCRIPTION
Adds expires option:

```
expires:%timestamp
exp:%timestamp
```

When set, imgproxy will check provided timestamp and return 404 when expired.

Default: empty

Closes #549