### PR TITLE
Skip processing option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- `IMGPROXY_FALLBACK_IMAGE_HTTP_CODE` config.
+- [expires](https://docs.imgproxy.net/#/generating_the_url?id=expires) processing option.
+- [skip processing](https://docs.imgproxy.net/#/generating_the_url?id=skip-processing) processing option.
+
 ### Removed
 - Removed basic URL format, use [advanced one](./docs/generating_the_url.md) instead.
 - Removed `IMGPROXY_MAX_SRC_DIMENSION` config, use `IMGPROXY_MAX_SRC_RESOLUTION` instead.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,7 +195,7 @@ You can configure imgproxy to skip processing of some formats:
 
 **📝Note:** Processing can be skipped only when the requested format is the same as the source format.
 
-**📝Note:** Video thumbnails processing can't be skipped.
+**📝Note:** Video thumbnail processing can't be skipped.
 
 ## Presets
 

--- a/docs/generating_the_url.md
+++ b/docs/generating_the_url.md
@@ -518,6 +518,21 @@ ar:%auto_rotate
 
 When set to `1`, `t` or `true`, imgproxy will automatically rotate images based onon the EXIF Orientation parameter (if available in the image meta data). The orientation tag will be removed from the image anyway. Normally this is controlled by the [IMGPROXY_AUTO_ROTATE](configuration.md#miscellaneous) configuration but this procesing option allows the configuration to be set for each request.
 
+### Skip processing
+
+```
+skip_processing:%extension1:%extension2:...:%extensionN
+skp:%extension1:%extension2:...:%extensionN
+```
+
+When set, imgproxy will skip the processing of listed formats. Also available as [IMGPROXY_SKIP_PROCESSING_FORMATS](configuration.md#skip-processing) configuration.
+
+**📝Note:** Processing can be skipped only when the requested format is the same as the source format.
+
+**📝Note:** Video thumbnail processing can't be skipped.
+
+Default: empty
+
 ### Filename
 
 ```

--- a/processing_handler.go
+++ b/processing_handler.go
@@ -185,11 +185,11 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 	checkTimeout(ctx)
 
 	po := getProcessingOptions(ctx)
-	if len(conf.SkipProcessingFormats) > 0 || len(po.SkipProcessingFormats) > 0 {
+	if len(po.SkipProcessingFormats) > 0 {
 		imgdata := getImageData(ctx)
 
 		if imgdata.Type == po.Format || po.Format == imageTypeUnknown {
-			for _, f := range append(conf.SkipProcessingFormats, po.SkipProcessingFormats...) {
+			for _, f := range po.SkipProcessingFormats {
 				if f == imgdata.Type {
 					po.Format = imgdata.Type
 					respondWithImage(ctx, reqID, r, rw, imgdata.Data)

--- a/processing_handler.go
+++ b/processing_handler.go
@@ -184,12 +184,12 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 
 	checkTimeout(ctx)
 
-	if len(conf.SkipProcessingFormats) > 0 {
+	po := getProcessingOptions(ctx)
+	if len(conf.SkipProcessingFormats) > 0 || len(po.SkipProcessingFormats) > 0 {
 		imgdata := getImageData(ctx)
-		po := getProcessingOptions(ctx)
 
 		if imgdata.Type == po.Format || po.Format == imageTypeUnknown {
-			for _, f := range conf.SkipProcessingFormats {
+			for _, f := range append(conf.SkipProcessingFormats, po.SkipProcessingFormats...) {
 				if f == imgdata.Type {
 					po.Format = imgdata.Type
 					respondWithImage(ctx, reqID, r, rw, imgdata.Data)

--- a/processing_options.go
+++ b/processing_options.go
@@ -147,6 +147,8 @@ type processingOptions struct {
 	StripColorProfile bool
 	AutoRotate        bool
 
+	SkipProcessingFormats []imageType
+
 	CacheBuster string
 
 	Watermark watermarkOptions
@@ -880,6 +882,18 @@ func applyCacheBusterOption(po *processingOptions, args []string) error {
 	return nil
 }
 
+func applySkipProcessingFormatsOption(po *processingOptions, args []string) error {
+	for _, format := range args {
+		if f, ok := imageTypes[format]; ok {
+			po.SkipProcessingFormats = append(po.SkipProcessingFormats, f)
+		} else {
+			return fmt.Errorf("Invalid image format in skip processing: %s", format)
+		}
+	}
+
+	return nil
+}
+
 func applyFilenameOption(po *processingOptions, args []string) error {
 	if len(args) > 1 {
 		return fmt.Errorf("Invalid filename arguments: %v", args)
@@ -989,6 +1003,8 @@ func applyProcessingOption(po *processingOptions, name string, args []string) er
 		return applyStripColorProfileOption(po, args)
 	case "auto_rotate", "ar":
 		return applyAutoRotateOption(po, args)
+	case "skip_processing", "skp":
+		return applySkipProcessingFormatsOption(po, args)
 	case "filename", "fn":
 		return applyFilenameOption(po, args)
 	case "expires", "exp":

--- a/processing_options.go
+++ b/processing_options.go
@@ -243,6 +243,7 @@ func newProcessingOptions() *processingOptions {
 	})
 
 	po := _newProcessingOptions
+	po.SkipProcessingFormats = append([]imageType(nil), conf.SkipProcessingFormats...)
 	po.UsedPresets = make([]string, 0, len(conf.Presets))
 
 	return &po

--- a/processing_options_test.go
+++ b/processing_options_test.go
@@ -568,6 +568,26 @@ func (s *ProcessingOptionsTestSuite) TestParsePathOnlyPresets() {
 	assert.Equal(s.T(), 50, po.Quality)
 }
 
+func (s *ProcessingOptionsTestSuite) TestParseSkipProcessing() {
+	req := s.getRequest("/unsafe/skp:jpg:png/plain/http://images.dev/lorem/ipsum.jpg")
+
+	ctx, err := parsePath(context.Background(), req)
+
+	require.Nil(s.T(), err)
+
+	po := getProcessingOptions(ctx)
+	assert.Equal(s.T(), []imageType{imageTypeJPEG, imageTypePNG}, po.SkipProcessingFormats)
+}
+
+func (s *ProcessingOptionsTestSuite) TestParseSkipProcessingInvalid() {
+	req := s.getRequest("/unsafe/skp:jpg:png:bad_format/plain/http://images.dev/lorem/ipsum.jpg")
+
+	_, err := parsePath(context.Background(), req)
+
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), "Invalid image format in skip processing: bad_format", err.Error())
+}
+
 func (s *ProcessingOptionsTestSuite) TestParseExpires() {
 	req := s.getRequest("/unsafe/exp:32503669200/plain/http://images.dev/lorem/ipsum.jpg")
 	_, err := parsePath(context.Background(), req)


### PR DESCRIPTION
Adds skip processing option

```
skip_processing:%extension1:%extension2:...:%extensionN
skp:%extension1:%extension2:...:%extensionN
```

When set, imgproxy will skip the processing of listed formats. Also available as `IMGPROXY_SKIP_PROCESSING_FORMATS` configuration.

**📝Note:** Processing can be skipped only when the requested format is the same as the source format.

**📝Note:** Video thumbnail processing can't be skipped.

Default: empty

Closes #476