### PR TITLE
Add Github action to notify imgproxy-helm about updates

### DIFF
--- a/.github/actions/notify-imgproxy-helm.yml
+++ b/.github/actions/notify-imgproxy-helm.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1.1.3
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.HELM_REPO_ACCESS_TOKEN }}
           repository: imgproxy/imgproxy-helm
           event-type: imgproxy-config-updated
           client-payload: '{"actor":"{{ github.actor }}","link":"https://github.com/imgproxy/imgproxy/commit/{{ github.sha }}#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180"}'

--- a/.github/actions/notify-imgproxy-helm.yml
+++ b/.github/actions/notify-imgproxy-helm.yml
@@ -1,0 +1,19 @@
+---
+name: Notify imgproxy/helm on updated 'configuration' part of the docs
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - docs/configuration.md
+jobs:
+  notify-imgproxy-helm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1.1.3
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: imgproxy/imgproxy-helm
+          event-type: imgproxy-config-updated
+          client-payload: '{"actor":"{{ github.actor }}","link":"https://github.com/imgproxy/imgproxy/commit/{{ github.sha }}#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180"}'


### PR DESCRIPTION
The action sends event to the [imgproxy-helm](https://github.com:imgproxy/imgproxy-helm) abount any update in the master branch of the main repository.

This [PR](https://github.com/imgproxy/imgproxy-helm/pull/25) adds another action handing the event and publishing an issue about the update. That's how we can shorten the cycle of updating Helm chart for the new version of the app.

---

@DarthSim For this action to work you should create a token with write access and register it in this repository as the `HELM_REPO_ACCESS_TOKEN`. Feel free to call me on Slack in case of any difficulties with this ))