### PR TITLE
Support wildcards with * in AllowedSources (excluding slashes)

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,22 +37,6 @@ func strEnvConfig(s *string, name string) {
 	}
 }
 
-func strSliceEnvConfig(s *[]string, name string) {
-	if env := os.Getenv(name); len(env) > 0 {
-		parts := strings.Split(env, ",")
-
-		for i, p := range parts {
-			parts[i] = strings.TrimSpace(p)
-		}
-
-		*s = parts
-
-		return
-	}
-
-	*s = []string{}
-}
-
 func boolEnvConfig(b *bool, name string) {
 	if env, err := strconv.ParseBool(os.Getenv(name)); err == nil {
 		*b = env
@@ -208,13 +192,9 @@ func patternsEnvConfig(s *[]*regexp.Regexp, name string) {
 		}
 
 		*s = result
-
-		return
+	} else {
+		*s = []*regexp.Regexp{}
 	}
-
-	*s = []*regexp.Regexp{}
-
-	return
 }
 
 func regexpFromPattern(pattern string) *regexp.Regexp {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,7 +73,7 @@ imgproxy does not send CORS headers by default. Specify allowed origin to enable
 
 You can limit allowed source URLs:
 
-* `IMGPROXY_ALLOWED_SOURCES`: whitelist of source image URLs prefixes divided by comma. When blank, imgproxy allows all source image URLs. Example: `s3://,https://example.com/,local://`. Default: blank.
+* `IMGPROXY_ALLOWED_SOURCES`: whitelist of source image URLs prefixes divided by comma. Wildcards can be included with `*` to match all characters except `/`. When blank, imgproxy allows all source image URLs. Example: `s3://,https://*.example.com/,local://`. Default: blank.
 
 **⚠️Warning:** Be careful when using this config to limit source URL hosts, and always add a trailing slash after the host. Bad: `http://example.com`, good: `http://example.com/`. If you don't add a trailing slash, `http://example.com@baddomain.com` will be an allowed URL but the request will be made to `baddomain.com`.
 

--- a/processing_options.go
+++ b/processing_options.go
@@ -993,28 +993,12 @@ func isAllowedSource(imageURL string) bool {
 	if len(conf.AllowedSources) == 0 {
 		return true
 	}
-	for _, val := range conf.AllowedSources {
-		if match, _ := regexp.MatchString(regexpFromPattern(val), imageURL); match {
+	for _, allowedSource := range conf.AllowedSources {
+		if allowedSource.MatchString(imageURL) {
 			return true
 		}
 	}
 	return false
-}
-
-func regexpFromPattern(pattern string) string {
-	var result strings.Builder
-	// Perform prefix matching
-	result.WriteString("^")
-	for i, part := range strings.Split(pattern, "*") {
-		// Add a regexp match all without slashes for each wildcard character
-		if i > 0 {
-			result.WriteString("[^/]*")
-		}
-
-		// Quote other parts of the pattern
-		result.WriteString(regexp.QuoteMeta(part))
-	}
-	return result.String()
 }
 
 func parseURLOptions(opts []string) (urlOptions, []string) {

--- a/processing_options.go
+++ b/processing_options.go
@@ -994,11 +994,27 @@ func isAllowedSource(imageURL string) bool {
 		return true
 	}
 	for _, val := range conf.AllowedSources {
-		if strings.HasPrefix(imageURL, string(val)) {
+		if match, _ := regexp.MatchString(regexpFromPattern(val), imageURL); match {
 			return true
 		}
 	}
 	return false
+}
+
+func regexpFromPattern(pattern string) string {
+	var result strings.Builder
+	// Perform prefix matching
+	result.WriteString("^")
+	for i, part := range strings.Split(pattern, "*") {
+		// Add a regexp match all without slashes for each wildcard character
+		if i > 0 {
+			result.WriteString("[^/]*")
+		}
+
+		// Quote other parts of the pattern
+		result.WriteString(regexp.QuoteMeta(part))
+	}
+	return result.String()
 }
 
 func parseURLOptions(opts []string) (urlOptions, []string) {

--- a/processing_options_test.go
+++ b/processing_options_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -146,7 +147,12 @@ func (s *ProcessingOptionsTestSuite) TestParseURLAllowedSources() {
 
 	for _, tc := range tt {
 		s.T().Run(tc.name, func(t *testing.T) {
-			conf.AllowedSources = tc.allowedSources
+			exps := make([]*regexp.Regexp, len(tc.allowedSources))
+			for i, pattern := range tc.allowedSources {
+				exps[i] = regexpFromPattern(pattern)
+			}
+			conf.AllowedSources = exps
+
 			req := s.getRequest(tc.requestPath)
 			_, err := parsePath(context.Background(), req)
 			if tc.expectedError {

--- a/processing_options_test.go
+++ b/processing_options_test.go
@@ -105,22 +105,57 @@ func (s *ProcessingOptionsTestSuite) TestParsePlainURLEscapedWithBase() {
 	assert.Equal(s.T(), imageTypePNG, getProcessingOptions(ctx).Format)
 }
 
-func (s *ProcessingOptionsTestSuite) TestParseURLAllowedSource() {
-	conf.AllowedSources = []string{"local://", "http://images.dev/"}
+func (s *ProcessingOptionsTestSuite) TestParseURLAllowedSources() {
+	tt := []struct {
+		name           string
+		allowedSources []string
+		requestPath    string
+		expectedError  bool
+	}{
+		{
+			name:           "match http URL without wildcard",
+			allowedSources: []string{"local://", "http://images.dev/"},
+			requestPath:    "/unsafe/plain/http://images.dev/lorem/ipsum.jpg",
+			expectedError:  false,
+		},
+		{
+			name:           "match http URL with wildcard in hostname single level",
+			allowedSources: []string{"local://", "http://*.mycdn.dev/"},
+			requestPath:    "/unsafe/plain/http://a-1.mycdn.dev/lorem/ipsum.jpg",
+			expectedError:  false,
+		},
+		{
+			name:           "match http URL with wildcard in hostname multiple levels",
+			allowedSources: []string{"local://", "http://*.mycdn.dev/"},
+			requestPath:    "/unsafe/plain/http://a-1.b-2.mycdn.dev/lorem/ipsum.jpg",
+			expectedError:  false,
+		},
+		{
+			name:           "no match s3 URL with allowed local and http URLs",
+			allowedSources: []string{"local://", "http://images.dev/"},
+			requestPath:    "/unsafe/plain/s3://images/lorem/ipsum.jpg",
+			expectedError:  true,
+		},
+		{
+			name:           "no match http URL with wildcard in hostname including slash",
+			allowedSources: []string{"local://", "http://*.mycdn.dev/"},
+			requestPath:    "/unsafe/plain/http://other.dev/.mycdn.dev/lorem/ipsum.jpg",
+			expectedError:  true,
+		},
+	}
 
-	req := s.getRequest("/unsafe/plain/http://images.dev/lorem/ipsum.jpg")
-	_, err := parsePath(context.Background(), req)
-
-	require.Nil(s.T(), err)
-}
-
-func (s *ProcessingOptionsTestSuite) TestParseURLNotAllowedSource() {
-	conf.AllowedSources = []string{"local://", "http://images.dev/"}
-
-	req := s.getRequest("/unsafe/plain/s3://images/lorem/ipsum.jpg")
-	_, err := parsePath(context.Background(), req)
-
-	require.Error(s.T(), err)
+	for _, tc := range tt {
+		s.T().Run(tc.name, func(t *testing.T) {
+			conf.AllowedSources = tc.allowedSources
+			req := s.getRequest(tc.requestPath)
+			_, err := parsePath(context.Background(), req)
+			if tc.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }
 
 func (s *ProcessingOptionsTestSuite) TestParsePathBasic() {


### PR DESCRIPTION
For some cases like CDNs or other use-cases where subdomains are involved there is no way to define `IMGPROXY_ALLOWED_SOURCES` with all possible URLs.

This change adds support with a wildcard character `*` that matches every non-slash character. It keeps matching of prefixes and uses Go regexps internally.