### PR TITLE
Fix typo in response header name

### DIFF
--- a/landing.go
+++ b/landing.go
@@ -14,7 +14,7 @@ var landingTmpl = []byte(`
 `)
 
 func handleLanding(reqID string, rw http.ResponseWriter, r *http.Request) {
-	rw.Header().Set("Content-Tyle", "text/html")
+	rw.Header().Set("Content-Type", "text/html")
 	rw.WriteHeader(200)
 	rw.Write(landingTmpl)
 }


### PR DESCRIPTION
Hi there,

I noticed this typo for the `Content-Type` header on the landing page. Here's a fix.

Kind regards,
Hampus Kraft.