### PR TITLE
Implement cookie passthrough

### DIFF
--- a/config.go
+++ b/config.go
@@ -226,6 +226,7 @@ type config struct {
 
 	TTL                     int
 	CacheControlPassthrough bool
+	CookiePassthrough       bool
 	SetCanonicalHeader      bool
 
 	SoReuseport bool
@@ -289,7 +290,8 @@ type config struct {
 
 	ETagEnabled bool
 
-	BaseURL string
+	BaseURL          string
+	CookieBaseURL    string
 
 	Presets     presets
 	OnlyPresets bool
@@ -384,6 +386,7 @@ func configure() error {
 
 	intEnvConfig(&conf.TTL, "IMGPROXY_TTL")
 	boolEnvConfig(&conf.CacheControlPassthrough, "IMGPROXY_CACHE_CONTROL_PASSTHROUGH")
+	boolEnvConfig(&conf.CookiePassthrough, "IMGPROXY_COOKIE_PASSTHROUGH")
 	boolEnvConfig(&conf.SetCanonicalHeader, "IMGPROXY_SET_CANONICAL_HEADER")
 
 	boolEnvConfig(&conf.SoReuseport, "IMGPROXY_SO_REUSEPORT")
@@ -467,6 +470,7 @@ func configure() error {
 	boolEnvConfig(&conf.ETagEnabled, "IMGPROXY_USE_ETAG")
 
 	strEnvConfig(&conf.BaseURL, "IMGPROXY_BASE_URL")
+	strEnvConfig(&conf.CookieBaseURL, "IMGPROXY_COOKIE_BASE_URL")
 
 	if err := presetEnvConfig(conf.Presets, "IMGPROXY_PRESETS"); err != nil {
 		return err

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,16 @@ Also you may want imgproxy to respond with the same error message that it writes
 
 * `IMGPROXY_DEVELOPMENT_ERRORS_MODE`: when true, imgproxy will respond with detailed error messages. Not recommended for production because some errors may contain stack trace.
 
+## Cookies
+
+imgproxy can pass through cookies in image requests. This can be activated with `IMGPROXY_COOKIE_PASSTHROUGH`. Unfortunately a `Cookie` header doesn't contain information for which URLs these cookies are applicable, so imgproxy can only assume (or must be told).
+
+When cookie forwarding is activated, imgproxy by default assumes the scope of the cookies to be all URLs with the same hostname/port and request scheme as given by the headers `X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-Scheme` or `Host`. To change that use `IMGPROXY_COOKIE_BASE_URL`.
+
+* `IMGPROXY_COOKIE_PASSTHROUGH`: when `true`, incoming cookies will be passed through to the image request if they are applicable for the image URL. Default: false;
+
+* `IMGPROXY_COOKIE_BASE_URL`: when set, assume that cookies have a scope of this URL for the incoming request (instead of using the request headers). If the cookies are applicable to the image URL too, they will be passed along in the image request.
+
 ## Compression
 
 * `IMGPROXY_QUALITY`: default quality of the resulting image, percentage. Default: `80`;

--- a/image_data.go
+++ b/image_data.go
@@ -87,7 +87,7 @@ func fileImageData(path, desc string) (*imageData, error) {
 }
 
 func remoteImageData(imageURL, desc string) (*imageData, error) {
-	res, err := requestImage(imageURL)
+	res, err := requestImage(imageURL, nil)
 	if res != nil {
 		defer res.Body.Close()
 	}

--- a/processing_handler.go
+++ b/processing_handler.go
@@ -167,7 +167,7 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 		panic(err)
 	}
 
-	ctx, downloadcancel, err := downloadImage(ctx)
+	ctx, downloadcancel, err := downloadImage(ctx, r)
 	defer downloadcancel()
 	if err != nil {
 		if newRelicEnabled {


### PR DESCRIPTION
This pull request implements the feature requested by https://github.com/imgproxy/imgproxy/issues/719

It adds options to pass through incoming cookies in the image request if they are applicable.

This behaviour gets activated when the environment variable `IMGPROXY_COOKIE_PASSTHROUGH` is set (without it no cookies will be passed through).

From `docs/configuration.md`:

> When cookie forwarding is activated, imgproxy by default assumes the scope of the cookies to be all URLs with the same hostname/port and request scheme as given by the headers `X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-Scheme` or `Host`. To change that use `IMGPROXY_COOKIE_BASE_URL`.
>
> * `IMGPROXY_COOKIE_PASSTHROUGH`: when `true`, incoming cookies will be passed through to the image request if they are applicable for the image URL. Default: false;
>
> * `IMGPROXY_COOKIE_BASE_URL`: when set, assume that cookies have a scope of this URL for the incoming request (instead of using the request headers). If the cookies are applicable to the image URL too, they will be passed along in the image request.
