### PR TITLE
fix: make text selection readable

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -148,3 +148,8 @@ h1 i.badge, h2 i.badge, h3 i.badge, h4 i.badge, .sidebar-nav i.badge {
   display: block;
   margin: 5px auto 0;
 }
+
+h1, h2, h3, h4, p::selection {
+  background-color: var(--link-color);
+}
+  


### PR DESCRIPTION
current setup results in low contrast between default text selection background color and text color. to fix this use link-color for text ::selection

## Before
<img width="1392" alt="Screenshot 2021-12-22 at 07 38 08" src="https://user-images.githubusercontent.com/2504771/147037603-d31c4fb0-8684-4f62-aa4b-411846a4edbd.png">

## After
<img width="1392" alt="Screenshot 2021-12-22 at 07 46 48" src="https://user-images.githubusercontent.com/2504771/147037638-211ee525-27f5-4f34-8560-dc804d0062ed.png">

