### PR TITLE
Add support for TextFormatter aka logfmt

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -367,6 +367,7 @@ imgproxy can report occurred errors to Bugsnag, Honeybadger and Sentry:
   * `pretty`: _(default)_ colored human-readable format
   * `structured`: machine-readable format
   * `json`: JSON format
+  * `text`: logfmt format
 * `IMGPROXY_LOG_LEVEL`: the log level. The following levels are supported `error`, `warn`, `info` and `debug`. Default: `info`
 
 imgproxy can send logs to syslog, but this feature is disabled by default. To enable it, set `IMGPROXY_SYSLOG_ENABLE` to `true`:

--- a/logger/log.go
+++ b/logger/log.go
@@ -24,6 +24,8 @@ func Init() error {
 		logrus.SetFormatter(&structuredFormatter{})
 	case "json":
 		logrus.SetFormatter(&logrus.JSONFormatter{})
+	case "text":
+		logrus.SetFormatter(&logrus.TextFormatter{})
 	default:
 		logrus.SetFormatter(newPrettyFormatter())
 	}


### PR DESCRIPTION
Add support for TextFormatter which is compatible with logfmt

![image](https://user-images.githubusercontent.com/982752/153604012-985e47bb-0631-4aba-bc28-bb515e02c4b1.png)


This is very similar to the custom "structured" format.