### PR TITLE
Respond with 404 when the source image can not be found in OpenStack Object Storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fix
 - Fix trimming of CMYK images.
+- Respond with 404 when the source image can not be found in OpenStack Object Storage.
 
 ## [3.6.0] - 2022-06-13
 ### Add

--- a/transport/swift/swift_test.go
+++ b/transport/swift/swift_test.go
@@ -90,6 +90,24 @@ func (s *SwiftTestSuite) TestRoundTripWithETagDisabledReturns200() {
 	require.Equal(s.T(), 200, response.StatusCode)
 }
 
+func (s *SwiftTestSuite) TestRoundTripReturns404WhenObjectNotFound() {
+	config.ETagEnabled = true
+	request, _ := http.NewRequest("GET", "swift://test/foo/not-here.png", nil)
+
+	response, err := s.transport.RoundTrip(request)
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), 404, response.StatusCode)
+}
+
+func (s *SwiftTestSuite) TestRoundTripReturns404WhenContainerNotFound() {
+	config.ETagEnabled = true
+	request, _ := http.NewRequest("GET", "swift://invalid/foo/test.png", nil)
+
+	response, err := s.transport.RoundTrip(request)
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), 404, response.StatusCode)
+}
+
 func (s *SwiftTestSuite) TestRoundTripWithETagEnabled() {
 	config.ETagEnabled = true
 	request, _ := http.NewRequest("GET", "swift://test/foo/test.png", nil)


### PR DESCRIPTION
Does what the title says so imgproxy doesn't throw a 500 when it should return 404.

Review please. 🙏 