### PR TITLE
Avoid sending invalid png bitdepth to libvips

### DIFF
--- a/vips/vips.c
+++ b/vips/vips.c
@@ -591,6 +591,8 @@ vips_pngsave_go(VipsImage *in, void **buf, size_t *len, int interlace, int quant
   } else {
     bitdepth = vips_get_palette_bit_depth(in);
     if (bitdepth) {
+      if (bitdepth > 4) bitdepth = 8;
+      else if (bitdepth > 2) bitdepth = 4;
       quantize = 1;
       colors = 1 << bitdepth;
     }


### PR DESCRIPTION
In our environment we had to upgrade to libvips 8.13.0-rc1 for better gif support. It worked pretty well except for gif to png conversion.

For example, this gif file, <https://www.w3.org/People/mimasa/test/imgformat/img/w3c_home.gif>, has the bit depth of `6`, which is [not a valid png bit depth](https://github.com/glennrp/libpng/blob/2c0aee5/png.c#L2622-L2627). 

```
➜  imgproxy vipsheader -a  w3c_home.gif  | grep bit-depth
memory: high-water mark 0 bytes
palette-bit-depth: 6
```

Interestingly, this wasn't an issue with libvips 8.12.2 because `vips_image_get_typeof(image, "palette-bit-depth")` returns `G_TYPE_INVALID` for some reason and `vips_get_palette_bit_depth()` always returns `0` - https://github.com/imgproxy/imgproxy/blob/7a50741/vips/vips.c#L128 

With libvips 8.13.0-rc1, however, `vips_image_get_typeof(image, "palette-bit-depth")` returns `G_TYPE_INT` as expected, and so the bitdepth `6` might be used to save the png file. As a result, the following error would occur:
```
INFO    [2022-07-05T17:21:40+10:00] Started /rs:fit/el:1/q:90/w:960/h:5120/plain/https://www.w3.org/People/mimasa/test/imgformat/img/w3c_home.gif@png  request_id=04OsjiB8nmf-2aA-UEl6L method=GET client_ip=127.0.0.1

(process:88655): VIPS-WARNING **: 17:21:41.824: Invalid bit depth in IHDR

(process:88655): VIPS-WARNING **: 17:21:41.824: Invalid IHDR data
ERROR   [2022-07-05T17:21:41+10:00] Completed in 1.094819019s /rs:fit/el:1/q:90/w:960/h:5120/plain/https://www.w3.org/People/mimasa/test/imgformat/img/w3c_home.gif@png  request_id=04OsjiB8nmf-2aA-UEl6L method=GET status=500 client_ip=127.0.0.1 error="vips2png: unable to write to target target\n"
/Users/joe.cai/git/imgproxy/vips/vips.go:301 github.com/imgproxy/imgproxy/v3/vips.(*Image).Save
/Users/joe.cai/git/imgproxy/processing/processing.go:288 github.com/imgproxy/imgproxy/v3/processing.ProcessImage
/Users/joe.cai/git/imgproxy/processing_handler.go:324 main.handleProcessing.func3
/Users/joe.cai/git/imgproxy/processing_handler.go:322 main.handleProcessing
/Users/joe.cai/git/imgproxy/server.go:103 main.withCORS.func1
/Users/joe.cai/git/imgproxy/server.go:150 main.withPanicHandler.func1
/Users/joe.cai/git/imgproxy/router/router.go:102 github.com/imgproxy/imgproxy/v3/router.(*Router).ServeHTTP
/usr/local/Cellar/go/1.18.3/libexec/src/net/http/server.go:2917 net/http.serverHandler.ServeHTTP
/usr/local/Cellar/go/1.18.3/libexec/src/net/http/server.go:1967 net/http.(*conn).serve
/usr/local/Cellar/go/1.18.3/libexec/src/runtime/asm_amd64.s:1572 runtime.goexit
```

The PR fixes the issue by ignoring invalid png bitdepth.
```
INFO    [2022-07-05T17:35:48+10:00] Started /rs:fit/el:1/q:90/w:960/h:5120/plain/https://www.w3.org/People/mimasa/test/imgformat/img/w3c_home.gif@png  request_id=QWF5UYyg3etVL0Xocjnlw method=GET client_ip=127.0.0.1
INFO    [2022-07-05T17:35:49+10:00] Completed in 1.049611546s /rs:fit/el:1/q:90/w:960/h:5120/plain/https://www.w3.org/People/mimasa/test/imgformat/img/w3c_home.gif@png  request_id=QWF5UYyg3etVL0Xocjnlw method=GET status=200 client_ip=127.0.0.1 processing_options="Width: 960; Height: 5120; Enlarge: true; Format: png; Quality: 90" image_url="https://www.w3.org/People/mimasa/test/imgformat/img/w3c_home.gif"
```

Please review. 🙏 

