### PR TITLE
Set png bitdepth > 8  to 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fix
 - Fix trimming of CMYK images.
 - Respond with 404 when the source image can not be found in OpenStack Object Storage.
+- Ensure the correct bitdepth is set when converting GIF to PNG.
 
 ## [3.6.0] - 2022-06-13
 ### Add

--- a/vips/vips.c
+++ b/vips/vips.c
@@ -591,7 +591,8 @@ vips_pngsave_go(VipsImage *in, void **buf, size_t *len, int interlace, int quant
   } else {
     bitdepth = vips_get_palette_bit_depth(in);
     if (bitdepth) {
-      if (bitdepth > 4) bitdepth = 8;
+      if (bitdepth > 8) bitdepth = 16;
+      else if (bitdepth > 4) bitdepth = 8;
       else if (bitdepth > 2) bitdepth = 4;
       quantize = 1;
       colors = 1 << bitdepth;


### PR DESCRIPTION
Hi @DarthSim . I just realised that a bitdepth of 16 is actually possible for PNG files if the source image is not a GIF file. This fixes the regression from https://github.com/imgproxy/imgproxy/pull/915 . 

Please review. Thanks 🙏 