### PR TITLE
use UTF8 to encode url to base64

### DIFF
--- a/examples/signature.cs
+++ b/examples/signature.cs
@@ -63,6 +63,6 @@ namespace ImgProxy.Examples
             => Convert.ToBase64String(stream).TrimEnd('=').Replace('+', '-').Replace('/', '_');
 
         static string EncodeBase64URLSafeString(this string str)
-            => EncodeBase64URLSafeString(Encoding.ASCII.GetBytes(str));
+            => EncodeBase64URLSafeString(Encoding.UTF8.GetBytes(str));
     }
 }


### PR DESCRIPTION
the example looks wrong to use UTF8 at one place and ASCII the other place.