### PR TITLE
Whitelist processing options

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -117,8 +117,9 @@ var (
 
 	BaseURL string
 
-	Presets     []string
-	OnlyPresets bool
+	WhitelistProcessingOpts []string
+	Presets                 []string
+	OnlyPresets             bool
 
 	WatermarkData    string
 	WatermarkPath    string
@@ -284,6 +285,7 @@ func Reset() {
 
 	BaseURL = ""
 
+	WhitelistProcessingOpts = make([]string, 0)
 	Presets = make([]string, 0)
 	OnlyPresets = false
 
@@ -458,6 +460,7 @@ func Configure() error {
 
 	configurators.String(&BaseURL, "IMGPROXY_BASE_URL")
 
+	configurators.StringSlice(&WhitelistProcessingOpts, "IMGPROXY_WHITELIST_PROCESSING_OPTS")
 	configurators.StringSlice(&Presets, "IMGPROXY_PRESETS")
 	if err := configurators.StringSliceFile(&Presets, presetsPath); err != nil {
 		return err

--- a/options/processing_options.go
+++ b/options/processing_options.go
@@ -946,12 +946,29 @@ func applyURLOption(po *ProcessingOptions, name string, args []string) error {
 
 func applyURLOptions(po *ProcessingOptions, options urlOptions) error {
 	for _, opt := range options {
+		if !isWhitelistedOption(opt) {
+			continue
+		}
+		
 		if err := applyURLOption(po, opt.Name, opt.Args); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+func isWhitelistedOption(option urlOption) bool {
+	if len(config.WhitelistProcessingOpts) == 0 {
+		return true
+	}
+
+	for _, v := range config.WhitelistProcessingOpts {
+		if v == option.Name {
+			return true
+		}
+	}
+	return false
 }
 
 func defaultProcessingOptions(headers http.Header) (*ProcessingOptions, error) {

--- a/options/processing_options_test.go
+++ b/options/processing_options_test.go
@@ -590,6 +590,24 @@ func (s *ProcessingOptionsTestSuite) TestParseBase64URLOnlyPresets() {
 	require.Equal(s.T(), originURL, imageURL)
 }
 
+func (s *ProcessingOptionsTestSuite) TestWhitelistProcessingOptions() {
+	config.WhitelistProcessingOpts = []string{"width", "height"}
+
+	originURL := "http://images.dev/lorem/ipsum.jpg"
+	path := fmt.Sprintf("/width:200/height:300/zoom:3:3/blur:0.2/plain/%s", originURL)
+
+	po, imageURL, err := ParsePath(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+
+	require.Equal(s.T(), float32(0), po.Blur)
+	require.Equal(s.T(), 200, po.Width)
+	require.Equal(s.T(), 300, po.Height)
+	require.Equal(s.T(), float64(1), po.ZoomWidth)
+	require.Equal(s.T(), float64(1), po.ZoomHeight)
+	require.Equal(s.T(), originURL, imageURL)
+}
+
 func TestProcessingOptions(t *testing.T) {
 	suite.Run(t, new(ProcessingOptionsTestSuite))
 }


### PR DESCRIPTION
This PR adds a new ENV `IMGPROXY_WHITELIST_PROCESSING_OPTS` which allows to whitelist only certain image processing operations and ignore all the others.

If not specified we retain the current behaviour of allowing all processing operations