### PR TITLE
feat(logger): implement structured log formatter gcp compliant

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -434,6 +434,7 @@ imgproxy can report occurred errors to Bugsnag, Honeybadger and Sentry:
   * `pretty`: _(default)_ colored human-readable format
   * `structured`: machine-readable format
   * `json`: JSON format
+  * `gcp`: Google Cloud Logging agent compliant
 * `IMGPROXY_LOG_LEVEL`: the log level. The following levels are supported `error`, `warn`, `info` and `debug`. Default: `info`
 
 imgproxy can send logs to syslog, but this feature is disabled by default. To enable it, set `IMGPROXY_SYSLOG_ENABLE` to `true`:

--- a/logger/log.go
+++ b/logger/log.go
@@ -23,6 +23,13 @@ func Init() error {
 		logrus.SetFormatter(&structuredFormatter{})
 	case "json":
 		logrus.SetFormatter(&logrus.JSONFormatter{})
+	case "gcp":
+		logrus.SetFormatter(&logrus.JSONFormatter{
+			FieldMap: logrus.FieldMap{
+				"level": "severity",
+				"msg":   "message",
+			},
+		})
 	default:
 		logrus.SetFormatter(newPrettyFormatter())
 	}


### PR DESCRIPTION
Hello,

If you start imgproxy with this env var : `IMGPROXY_LOG_FORMAT=gcp`, the log output will be much readable in GCP Log UI

https://cloud.google.com/logging/docs/structured-logging?hl=fr#special-payload-fields

Thanks