### PR TITLE
fix: rendering the pro image

### DIFF
--- a/docs/autoquality.md
+++ b/docs/autoquality.md
@@ -1,4 +1,4 @@
-# Autoquality![pro](/assets/pro.svg)
+# Autoquality![pro](./assets/pro.svg)
 
 imgproxy can calculate quality for your resultant images so they best fit the selected metric. The supported methods are [none](#none), [size](#autoquality-by-file-size), [dssim](#autoquality-by-dssim), and [ml](#autoquality-with-ml).
 

--- a/docs/best_format.md
+++ b/docs/best_format.md
@@ -1,4 +1,4 @@
-# Best format![pro](/assets/pro.svg)
+# Best format![pro](./assets/pro.svg)
 
 You can use the `best` value for the [format](generating_the_url#format) option or the [extension](generating_the_url#extension) to make imgproxy pick the best format for the resultant image.
 

--- a/docs/chained_pipelines.md
+++ b/docs/chained_pipelines.md
@@ -1,4 +1,4 @@
-# Chained pipelines![pro](/assets/pro.svg)
+# Chained pipelines![pro](./assets/pro.svg)
 
 Though imgproxy's [processing pipeline](about_processing_pipeline.md) is suitable for most cases, sometimes it's handy to run multiple chained pipelines with different options.
 

--- a/docs/chaining_the_processing.md
+++ b/docs/chaining_the_processing.md
@@ -1,4 +1,4 @@
-# Chaining the processing![pro](/assets/pro.svg)
+# Chaining the processing![pro](./assets/pro.svg)
 
 Though imgproxy's [processing pipeline](about_processing_pipeline.md) is suitable for most cases, sometimes it's handy to run multiple chained pipelines with different options.
 

--- a/docs/encrypting_the_source_url.md
+++ b/docs/encrypting_the_source_url.md
@@ -1,4 +1,4 @@
-# Encrypting the source URL![pro](/assets/pro.svg)
+# Encrypting the source URL![pro](./assets/pro.svg)
 
 If you don't want to reveal your source URLs, you can encrypt them with the AES-CBC algorithm.
 

--- a/docs/getting_the_image_info.md
+++ b/docs/getting_the_image_info.md
@@ -1,4 +1,4 @@
-# Getting the image info![pro](/assets/pro.svg)
+# Getting the image info![pro](./assets/pro.svg)
 
 imgproxy can fetch and return a source image info without downloading the whole image.
 

--- a/docs/object_detection.md
+++ b/docs/object_detection.md
@@ -1,4 +1,4 @@
-# Object detection![pro](/assets/pro.svg)
+# Object detection![pro](./assets/pro.svg)
 
 imgproxy can detect objects on the image and use them for smart cropping, bluring the detections, or drawing the detections.
 


### PR DESCRIPTION
I fixed the rendering of the pro image in the title of some of the doc files.

See: 

<img width="560" alt="pro" src="https://user-images.githubusercontent.com/26602940/207621194-eea9ada8-c032-477f-b2cb-7c162abeef3e.png">
