### PR TITLE
allow acquiring s3 access credentials through role assumption

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -97,9 +97,10 @@ var (
 
 	LocalFileSystemRoot string
 
-	S3Enabled  bool
-	S3Region   string
-	S3Endpoint string
+	S3Enabled       bool
+	S3Region        string
+	S3Endpoint      string
+	S3AssumeRoleArn string
 
 	GCSEnabled  bool
 	GCSKey      string
@@ -293,6 +294,7 @@ func Reset() {
 	S3Enabled = false
 	S3Region = ""
 	S3Endpoint = ""
+	S3AssumeRoleArn = ""
 	GCSEnabled = false
 	GCSKey = ""
 	ABSEnabled = false
@@ -490,6 +492,7 @@ func Configure() error {
 	configurators.Bool(&S3Enabled, "IMGPROXY_USE_S3")
 	configurators.String(&S3Region, "IMGPROXY_S3_REGION")
 	configurators.String(&S3Endpoint, "IMGPROXY_S3_ENDPOINT")
+	configurators.String(&S3AssumeRoleArn, "IMGPROXY_S3_ASSUME_ROLE_ARN")
 
 	configurators.Bool(&GCSEnabled, "IMGPROXY_USE_GCS")
 	configurators.String(&GCSKey, "IMGPROXY_GCS_KEY")

--- a/docs/serving_files_from_s3.md
+++ b/docs/serving_files_from_s3.md
@@ -6,7 +6,8 @@ imgproxy can process images from S3 buckets. To use this feature, do the followi
 2. [Set up the necessary credentials](#set-up-credentials) to grant access to your bucket.
 3. _(optional)_ Specify the AWS region with `IMGPROXY_S3_REGION` or `AWS_REGION`. Default: `us-west-1`
 4. _(optional)_ Specify the S3 endpoint with `IMGPROXY_S3_ENDPOINT`.
-5. Use `s3://%bucket_name/%file_key` as the source image URL.
+5. _(optional)_ Specify the AWS IAM Role to Assume with `IMGPROXY_S3_ASSUME_ROLE_ARN`
+6. Use `s3://%bucket_name/%file_key` as the source image URL.
 
 If you need to specify the version of the source object, you can use the query string of the source URL:
 
@@ -25,6 +26,8 @@ If you're running imgproxy on an Amazon Web Services platform, you can use IAM r
 * **Elastic Container Service (ECS):** Assign an [IAM role to a task](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).
 * **Elastic Kubernetes Service (EKS):** Assign a [service account to a pod](https://docs.aws.amazon.com/eks/latest/userguide/pod-configuration.html).
 * **Elastic Beanstalk:** Assign an [IAM role to an instance](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-instanceprofile.html).
+
+S3 access credentials may be acquired by assuming a role using STS. To do so specify the IAM Role arn with `IMGPROXY_S3_ASSUME_ROLE_ARN` environment variable. This approach still requires you to provide initial AWS credentials by using one of the three ways described above.
 
 #### Environment variables
 

--- a/transport/s3/s3.go
+++ b/transport/s3/s3.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -44,6 +45,10 @@ func New() (http.RoundTripper, error) {
 	sess, err := session.NewSession()
 	if err != nil {
 		return nil, fmt.Errorf("Can't create S3 session: %s", err)
+	}
+
+	if len(config.S3AssumeRoleArn) != 0 {
+		s3Conf.Credentials = stscreds.NewCredentials(sess, config.S3AssumeRoleArn)
 	}
 
 	if sess.Config.Region == nil || len(*sess.Config.Region) == 0 {


### PR DESCRIPTION
With this change I introduce means to override IAM role by ussing sts assume role.

This allows to access S3 buckets by ECS or any other services that run on different accounts and helps to maintain good IAM security practices. Prior to this a credential pair was required to be made a available to the imgproxy service.