### PR TITLE
Fix typo in presets docs

### DIFF
--- a/docs/presets.md
+++ b/docs/presets.md
@@ -30,4 +30,4 @@ Setting `IMGPROXY_ONLY_PRESETS` to `true` switches imgproxy into "presets-only m
 http://imgproxy.example.com/unsafe/thumbnail:blurry:watermarked/plain/http://example.com/images/curiosity.jpg@png
 ```
 
-All othe URL formats are disabled in this mode.
+All other URL formats are disabled in this mode.

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -30,4 +30,4 @@ Setting `IMGPROXY_ONLY_PRESETS` to `true` switches imgproxy into "presets-only m
 http://imgproxy.example.com/unsafe/thumbnail:blurry:watermarked/plain/http://example.com/images/curiosity.jpg@png
 ```
 
-All other URL formats are disabled in this mode.
+All others URL formats are disabled in this mode.

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -30,4 +30,4 @@ Setting `IMGPROXY_ONLY_PRESETS` to `true` switches imgproxy into "presets-only m
 http://imgproxy.example.com/unsafe/thumbnail:blurry:watermarked/plain/http://example.com/images/curiosity.jpg@png
 ```
 
-All others URL formats are disabled in this mode.
+All other URL formats are disabled in this mode.


### PR DESCRIPTION
Hello!

Thank you for imgproxy and for your work. 

Just a small typo in presets documentation.

----

By the way, I think it's good to mention in presets docs, that presets are better approach if you want to save imgproxy url in database. 

The reason is if a developer wants to change all thumbnails (just for example) urls he might just change preset without processing urls in database.

I didn't put this description in this PR because I'm not sure is it really "good to mention" or everyone know it anyway. 