### PR TITLE
Drop dependency + use built-in `base64url`

### DIFF
--- a/examples/signature.js
+++ b/examples/signature.js
@@ -1,11 +1,7 @@
-const createHmac = require('create-hmac')
+import { createHmac } from 'node:crypto';
 
 const KEY = '943b421c9eb07c830af81030552c86009268de4e532ba2ee2eab8247c6da0881'
 const SALT = '520f986b998545b4785e0defbc4f3c1203f22de2374a3d53cb7a7fe9fea309c5'
-
-const urlSafeBase64 = (string) => {
-  return Buffer.from(string).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_')
-}
 
 const hexDecode = (hex) => Buffer.from(hex, 'hex')
 
@@ -13,7 +9,8 @@ const sign = (salt, target, secret) => {
   const hmac = createHmac('sha256', hexDecode(secret))
   hmac.update(hexDecode(salt))
   hmac.update(target)
-  return urlSafeBase64(hmac.digest())
+
+  return hmac.digest().toString('base64url')
 }
 
 const path = "/rs:fit:300:300/plain/http://img.example.com/pretty/image.jpg"

--- a/examples/signature.js
+++ b/examples/signature.js
@@ -10,7 +10,7 @@ const sign = (salt, target, secret) => {
   hmac.update(hexDecode(salt))
   hmac.update(target)
 
-  return hmac.digest().toString('base64url')
+  return hmac.digest('base64url')
 }
 
 const path = "/rs:fit:300:300/plain/http://img.example.com/pretty/image.jpg"


### PR DESCRIPTION
[`create-hmac`](https://github.com/browserify/createHmac) is meant for compat between node and browser compat and was last updated in 2018.

Computing the HMAC signature on the client (browser) does not make any sense in 99% of the use-cases, as the secrets would be needed on the client side. This means that we can drop browser support and just use the native node module, which is also exported by the `create-hmac` when running on node.

`Buffer.toString()` also accepts "base64url" as an encoding, so we can drop the `urlSafeBase64` in favor of that.