### PR TITLE
Pass source IP validating headers from the original request

### DIFF
--- a/processing_handler.go
+++ b/processing_handler.go
@@ -257,6 +257,14 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 
 	imgRequestHeader := make(http.Header)
 
+	// Pass source IP validating headers from the original request.
+	headers := []string{"CF-Connecting-IP", "X-Real-IP", "X-Forwarded-For"}
+	for _, header := range headers {
+		if value := r.Header.Get(header); len(value) != 0 {
+			imgRequestHeader.Set(header, value)
+		}
+	}
+
 	var etagHandler etag.Handler
 
 	if config.ETagEnabled {


### PR DESCRIPTION
When downloading an image from the origin, we need to pass a real IP from the client to avoid blocking requests from self (in case the imgproxy/CDN edge node resides on the same box). Imgproxy requests an image using self IP, but it's blocked.