### PR TITLE
add query params support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,8 @@ var (
 
 	SoReuseport bool
 
-	PathPrefix string
+	PathPrefix     string
+	UseQueryParams bool
 
 	MaxSrcResolution            int
 	MaxSrcFileSize              int
@@ -229,6 +230,7 @@ func Reset() {
 	SoReuseport = false
 
 	PathPrefix = ""
+	UseQueryParams = false
 
 	MaxSrcResolution = 16800000
 	MaxSrcFileSize = 0
@@ -409,6 +411,7 @@ func Configure() error {
 	configurators.Bool(&SoReuseport, "IMGPROXY_SO_REUSEPORT")
 
 	configurators.URLPath(&PathPrefix, "IMGPROXY_PATH_PREFIX")
+	configurators.Bool(&UseQueryParams, "IMGPROXY_USE_QUERY_PARAMS")
 
 	configurators.MegaInt(&MaxSrcResolution, "IMGPROXY_MAX_SRC_RESOLUTION")
 	configurators.Int(&MaxSrcFileSize, "IMGPROXY_MAX_SRC_FILE_SIZE")

--- a/options/processing_options.go
+++ b/options/processing_options.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -1188,9 +1189,41 @@ func parsePathPresets(parts []string, headers http.Header) (*ProcessingOptions, 
 	return po, url, nil
 }
 
+func normilizeQueryParams(path string) (string, error) {
+	var queryStart int
+	if queryStart = strings.IndexByte(path, '?'); queryStart < 0 {
+		return path, nil
+	}
+
+	params := path[queryStart:]
+	path = path[:queryStart]
+
+	params, err := url.QueryUnescape(params)
+	if err != nil {
+		return "", err
+	}
+
+	params, err = url.QueryUnescape(params)
+	if err != nil {
+		return "", fmt.Errorf("query unescape: %w", err)
+	}
+
+	params = strings.ReplaceAll(params, "?", "/")
+	params = strings.ReplaceAll(params, "&", "/")
+	params = strings.ReplaceAll(params, "=", ":")
+
+	return params + path, nil
+}
+
 func ParsePath(path string, headers http.Header) (*ProcessingOptions, string, error) {
 	if path == "" || path == "/" {
 		return nil, "", ierrors.New(404, fmt.Sprintf("Invalid path: %s", path), "Invalid URL")
+	}
+
+	if normilizedPath, err := normilizeQueryParams(path); err != nil {
+		return nil, "", ierrors.New(404, fmt.Sprintf("Invalid path: %s", path), "Invalid Query Params")
+	} else {
+		path = normilizedPath
 	}
 
 	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")

--- a/options/processing_options_test.go
+++ b/options/processing_options_test.go
@@ -587,6 +587,18 @@ func (s *ProcessingOptionsTestSuite) TestParseBase64URLOnlyPresets() {
 	require.Equal(s.T(), originURL, imageURL)
 }
 
+func (s *ProcessingOptionsTestSuite) TestUseQueryParams() {
+	config.UseQueryParams = true
+	originURL := "http://images.dev/lorem/ipsum.jpg?param=value"
+	path := fmt.Sprintf("/%s?size=100:100&strip_metadata=true", base64.RawURLEncoding.EncodeToString([]byte(originURL)))
+	po, imageURL, err := ParsePath(path, make(http.Header))
+
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), originURL, imageURL)
+	require.Equal(s.T(), imagetype.Unknown, po.Format)
+	require.True(s.T(), po.StripMetadata)
+}
+
 func TestProcessingOptions(t *testing.T) {
 	suite.Run(t, new(ProcessingOptionsTestSuite))
 }

--- a/processing_handler.go
+++ b/processing_handler.go
@@ -209,7 +209,7 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 	}
 
 	path := r.RequestURI
-	if queryStart := strings.IndexByte(path, '?'); queryStart >= 0 {
+	if queryStart := strings.IndexByte(path, '?'); !config.UseQueryParams && queryStart >= 0 {
 		path = path[:queryStart]
 	}
 

--- a/processing_handler_test.go
+++ b/processing_handler_test.go
@@ -703,6 +703,23 @@ func (s *ProcessingHandlerTestSuite) TestModifiedSinceReqCompareTooOldLastModifi
 
 	require.Equal(s.T(), 200, res.StatusCode)
 }
+
+func (s *ProcessingHandlerTestSuite) TestQueryParams() {
+	config.UseQueryParams = true
+	rw := s.send("/unsafe/plain/local:///test1.png?rs=fill:4:4")
+	res := rw.Result()
+
+	require.Equal(s.T(), 200, res.StatusCode)
+	require.Equal(s.T(), "image/png", res.Header.Get("Content-Type"))
+
+	meta, err := imagemeta.DecodeMeta(res.Body)
+
+	require.Nil(s.T(), err)
+	require.Equal(s.T(), imagetype.PNG, meta.Format())
+	require.Equal(s.T(), 4, meta.Width())
+	require.Equal(s.T(), 4, meta.Height())
+}
+
 func TestProcessingHandler(t *testing.T) {
 	suite.Run(t, new(ProcessingHandlerTestSuite))
 }


### PR DESCRIPTION
What do you think about using query params?
This format is easiest to invalidate on CDNs. 
Signed requests will be able to invalidate too if a signature is in headers, not at the start of requests (I can make another pull request with this feature)

Examples of requests: 
```
http://imgproxy.example.com/insecure/aHR0cDovL2V4YW1w/bGUuY29tL2ltYWdl/cy9jdXJpb3NpdHku/anBn.png?rs=fill:300:400:0&g=sm

presets:
http://imgproxy.example.com/insecure/aHR0cDovL2V4YW1w/bGUuY29tL2ltYWdl/cy9jdXJpb3NpdHku/anBn.png?preset1&preset2
...
```

It's a simple draft and I'm new with imgproxy, so any questions and request's changes are welcome