### PR TITLE
fix(svg/sanitize): preserve headers from origin data

### DIFF
--- a/processing_handler.go
+++ b/processing_handler.go
@@ -362,7 +362,7 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 		// Don't process SVG
 		if originData.Type == imagetype.SVG {
 			if config.SanitizeSvg {
-				sanitized, svgErr := svg.Satitize(originData)
+				sanitized, svgErr := svg.Sanitize(originData)
 				checkErr(ctx, "svg_processing", svgErr)
 
 				// Since we'll replace origin data, it's better to close it to return

--- a/processing_handler_test.go
+++ b/processing_handler_test.go
@@ -317,11 +317,34 @@ func (s *ProcessingHandlerTestSuite) TestSkipProcessingSVG() {
 	require.Equal(s.T(), 200, res.StatusCode)
 
 	actual := s.readBody(res)
-	expected, err := svg.Satitize(&imagedata.ImageData{Data: s.readTestFile("test1.svg")})
+	expected, err := svg.Sanitize(&imagedata.ImageData{Data: s.readTestFile("test1.svg")})
 
 	require.Nil(s.T(), err)
 
 	require.True(s.T(), bytes.Equal(expected.Data, actual))
+}
+
+func (s *ProcessingHandlerTestSuite) TestPreserveOriginSVGHeaders() {
+	rw := s.send("/unsafe/rs:fill:4:4/plain/local:///test1.svg")
+	res := rw.Result()
+
+	require.Equal(s.T(), 200, res.StatusCode)
+
+	actual := s.readBody(res)
+	originHeaders := map[string]string{
+		"Content-Type":  "image/svg+xml",
+		"Cache-Control": "public, max-age=12345",
+	}
+
+	expected, err := svg.Sanitize(&imagedata.ImageData{
+		Data:    s.readTestFile("test1.svg"),
+		Headers: originHeaders,
+	})
+
+	require.Nil(s.T(), err)
+
+	require.True(s.T(), bytes.Equal(expected.Data, actual))
+	require.Equal(s.T(), originHeaders, expected.Headers)
 }
 
 func (s *ProcessingHandlerTestSuite) TestNotSkipProcessingSVGToJPG() {

--- a/svg/svg.go
+++ b/svg/svg.go
@@ -27,7 +27,7 @@ const feDropShadowTemplate = `
 	</feMerge>
 `
 
-func Satitize(data *imagedata.ImageData) (*imagedata.ImageData, error) {
+func Sanitize(data *imagedata.ImageData) (*imagedata.ImageData, error) {
 	r := bytes.NewReader(data.Data)
 	l := xml.NewLexer(parse.NewInput(r))
 
@@ -62,8 +62,9 @@ func Satitize(data *imagedata.ImageData) (*imagedata.ImageData, error) {
 			}
 
 			newData := imagedata.ImageData{
-				Data: buf.Bytes(),
-				Type: data.Type,
+				Data:    buf.Bytes(),
+				Type:    data.Type,
+				Headers: data.Headers,
 			}
 			newData.SetCancel(cancel)
 


### PR DESCRIPTION
`IMGPROXY_CACHE_CONTROL_PASSTHROUGH` doesn't work with `IMGPROXY_SANITIZE_SVG`

after calling `Sanitize`, cache-control headers are disappeared, so we need to preserve origin headers while creating a new `ImageData`