### PR TITLE
Update the signing the url HMAC generation

### DIFF
--- a/docs/signing_the_url.md
+++ b/docs/signing_the_url.md
@@ -49,10 +49,10 @@ IMGPROXY_KEY=736563726574 IMGPROXY_SALT=68656C6C6F imgproxy
 
 Note that all your unsigned URL will stop working since imgproxy now checks all URL signatures.
 
-First, you need to take the path after the signature and add the salt to the beginning:
+First, you need to take the path after the signature:
 
 ```
-hello/rs:fill:300:400:0/g:sm/aHR0cDovL2V4YW1w/bGUuY29tL2ltYWdl/cy9jdXJpb3NpdHku/anBn.png
+/rs:fill:300:400:0/g:sm/aHR0cDovL2V4YW1w/bGUuY29tL2ltYWdl/cy9jdXJpb3NpdHku/anBn.png
 ```
 
 Then calculate the HMAC digest of this string using SHA256 and encode it with URL-safe Base64:


### PR DESCRIPTION
With salt at the beginning it's giving a different hash which doesn't work with signature generated by imgproxy server. In the example, removing the salt at the beginning gave the correct signature `oKfUtW34Dvo2BGQehJFR4Nr0_rIjOtdtzJ3QFsUcXH8`