### PR TITLE
Fix to add null pointer in vips_copy method arguments

### DIFF
--- a/vips/vips.c
+++ b/vips/vips.c
@@ -244,7 +244,7 @@ vips_fix_float_tiff(VipsImage *in, VipsImage **out) {
   )
     return vips_fix_BW_float_tiff(in, out);
 
-  return vips_copy(in, out);
+  return vips_copy(in, out, NULL);
 }
 
 int


### PR DESCRIPTION
When compiling from source on Ubuntu we get an error: 

# github.com/imgproxy/imgproxy/v3/vips
vips.c: In function ‘vips_fix_float_tiff’:
vips.c:247:3: warning: not enough variable arguments to fit a sentinel [-Wformat=]
  247 |   return vips_copy(in, out);
      |   ^~~~~~

vips_copy has more arguments and call needs to be terminated with null pointer.

This fixes that problem.