### PR TITLE
Support encrypted client objects in S3 buckets

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -99,11 +99,12 @@ var (
 
 	LocalFileSystemRoot string
 
-	S3Enabled       bool
-	S3Region        string
-	S3Endpoint      string
-	S3AssumeRoleArn string
-	S3MultiRegion   bool
+	S3Enabled                 bool
+	S3Region                  string
+	S3Endpoint                string
+	S3AssumeRoleArn           string
+	S3MultiRegion             bool
+	S3DecryptionClientEnabled bool
 
 	GCSEnabled  bool
 	GCSKey      string
@@ -300,6 +301,7 @@ func Reset() {
 	S3Endpoint = ""
 	S3AssumeRoleArn = ""
 	S3MultiRegion = false
+	S3DecryptionClientEnabled = false
 	GCSEnabled = false
 	GCSKey = ""
 	ABSEnabled = false
@@ -501,6 +503,7 @@ func Configure() error {
 	configurators.String(&S3Endpoint, "IMGPROXY_S3_ENDPOINT")
 	configurators.String(&S3AssumeRoleArn, "IMGPROXY_S3_ASSUME_ROLE_ARN")
 	configurators.Bool(&S3MultiRegion, "IMGPROXY_S3_MULTI_REGION")
+	configurators.Bool(&S3DecryptionClientEnabled, "IMGPROXY_S3_USE_DECRYPTION_CLIENT")
 
 	configurators.Bool(&GCSEnabled, "IMGPROXY_USE_GCS")
 	configurators.String(&GCSKey, "IMGPROXY_GCS_KEY")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -371,6 +371,7 @@ imgproxy can process files from Amazon S3 buckets, but this feature is disabled 
 * `IMGPROXY_S3_REGION`: an S3 buckets region
 * `IMGPROXY_S3_ENDPOINT`: a custom S3 endpoint to being used by imgproxy
 * `IMGPROXY_S3_MULTI_REGION`: when `true`, allows using S3 buckets from different regions
+* `IMGPROXY_S3_USE_DECRYPTION_CLIENT`: when `true`, toggles client-side encryption
 
 Check out the [Serving files from S3](serving_files_from_s3.md) guide to learn more.
 

--- a/docs/serving_files_from_s3.md
+++ b/docs/serving_files_from_s3.md
@@ -7,8 +7,9 @@ imgproxy can process images from S3 buckets. To use this feature, do the followi
 3. _(optional)_ Specify the AWS region with `IMGPROXY_S3_REGION` or `AWS_REGION`. Default: `us-west-1`
 4. _(optional)_ Specify the S3 endpoint with `IMGPROXY_S3_ENDPOINT`.
 5. _(optional)_ Set the `IMGPROXY_S3_MULTI_REGION` environment variable to be `true`.
-6. _(optional)_ Specify the AWS IAM Role to Assume with `IMGPROXY_S3_ASSUME_ROLE_ARN`
-7. Use `s3://%bucket_name/%file_key` as the source image URL.
+6. _(optional)_ Set the `IMGPROXY_S3_USE_DECRYPTION_CLIENT` environment variable to `true` if your objects are encrypted.
+7. _(optional)_ Specify the AWS IAM Role to Assume with `IMGPROXY_S3_ASSUME_ROLE_ARN`
+8. Use `s3://%bucket_name/%file_key` as the source image URL.
 
 If you need to specify the version of the source object, you can use the query string of the source URL:
 

--- a/transport/s3/s3.go
+++ b/transport/s3/s3.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	http "net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -14,20 +15,28 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3crypto"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 
 	"github.com/imgproxy/imgproxy/v3/config"
 	defaultTransport "github.com/imgproxy/imgproxy/v3/transport"
 )
 
+type s3Client interface {
+	GetObjectRequest(input *s3.GetObjectInput) (req *request.Request, output *s3.GetObjectOutput)
+}
+
 // transport implements RoundTripper for the 's3' protocol.
 type transport struct {
-	session       *session.Session
-	defaultClient *s3.S3
+	session        *session.Session
+	defaultClient  s3Client
+	defaultConfig  *aws.Config
+	cryptoRegistry *s3crypto.CryptoRegistry
 
-	clientsByRegion map[string]*s3.S3
-	clientsByBucket map[string]*s3.S3
+	clientsByRegion map[string]s3Client
+	clientsByBucket map[string]s3Client
 
 	mu sync.RWMutex
 }
@@ -49,7 +58,7 @@ func New() (http.RoundTripper, error) {
 
 	sess, err := session.NewSession()
 	if err != nil {
-		return nil, fmt.Errorf("Can't create S3 session: %s", err)
+		return nil, fmt.Errorf("can't create S3 session: %s", err)
 	}
 
 	if len(config.S3Region) != 0 {
@@ -64,19 +73,25 @@ func New() (http.RoundTripper, error) {
 		conf.Credentials = stscreds.NewCredentials(sess, config.S3AssumeRoleArn)
 	}
 
-	client := s3.New(sess, conf)
-
-	clientRegion := "us-west-1"
-	if client.Config.Region != nil {
-		clientRegion = *client.Config.Region
+	cryptoRegistry, err := InitializeCryptoRegistry(sess)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't initialize S3 crypto registry: %s", err)
 	}
 
-	return &transport{
-		session:       sess,
-		defaultClient: client,
+	client, err := CreateClient(sess, conf, cryptoRegistry)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create S3 client: %s", err)
+	}
 
-		clientsByRegion: map[string]*s3.S3{clientRegion: client},
-		clientsByBucket: make(map[string]*s3.S3),
+	clientRegion := *sess.Config.Region
+
+	return &transport{
+		session:         sess,
+		defaultClient:   client,
+		defaultConfig:   conf,
+		cryptoRegistry:  cryptoRegistry,
+		clientsByRegion: map[string]s3Client{clientRegion: client},
+		clientsByBucket: make(map[string]s3Client),
 	}, nil
 }
 
@@ -113,7 +128,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return handleError(req, err)
 	}
 
-	s3req, _ := client.GetObjectRequest(input)
+	s3req, objectOutput := client.GetObjectRequest(input)
 	s3req.SetContext(req.Context())
 
 	if err := s3req.Send(); err != nil {
@@ -124,15 +139,27 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		return handleError(req, err)
 	}
 
+	if config.S3DecryptionClientEnabled {
+		s3req.HTTPResponse.Body = objectOutput.Body
+
+		if unencryptedContentLength := s3req.HTTPResponse.Header.Get("X-Amz-Meta-X-Amz-Unencrypted-Content-Length"); len(unencryptedContentLength) != 0 {
+			contentLength, err := strconv.ParseInt(unencryptedContentLength, 10, 64)
+			if err != nil {
+				handleError(req, err)
+			}
+			s3req.HTTPResponse.ContentLength = contentLength
+		}
+	}
+
 	return s3req.HTTPResponse, nil
 }
 
-func (t *transport) getClient(ctx context.Context, bucket string) (*s3.S3, error) {
+func (t *transport) getClient(ctx context.Context, bucket string) (s3Client, error) {
 	if !config.S3MultiRegion {
 		return t.defaultClient, nil
 	}
 
-	var client *s3.S3
+	var client s3Client
 
 	func() {
 		t.mu.RLock()
@@ -152,7 +179,7 @@ func (t *transport) getClient(ctx context.Context, bucket string) (*s3.S3, error
 		return client, nil
 	}
 
-	region, err := s3manager.GetBucketRegionWithClient(ctx, t.defaultClient, bucket)
+	region, err := s3manager.GetBucketRegion(ctx, t.session, bucket, *t.session.Config.Region)
 	if err != nil {
 		return nil, err
 	}
@@ -162,15 +189,43 @@ func (t *transport) getClient(ctx context.Context, bucket string) (*s3.S3, error
 		return client, nil
 	}
 
-	conf := t.defaultClient.Config.Copy()
+	conf := t.defaultConfig.Copy()
 	conf.Region = aws.String(region)
 
-	client = s3.New(t.session, conf)
+	client, err = CreateClient(t.session, conf, t.cryptoRegistry)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create regional S3 client: %s", err)
+	}
 
 	t.clientsByRegion[region] = client
 	t.clientsByBucket[bucket] = client
 
 	return client, nil
+}
+
+func CreateClient(session *session.Session, conf *aws.Config, cryptoRegistry *s3crypto.CryptoRegistry) (s3Client, error) {
+	if config.S3DecryptionClientEnabled {
+		return s3crypto.NewDecryptionClientV2(session, cryptoRegistry)
+	} else {
+		return s3.New(session, conf), nil
+	}
+}
+
+func InitializeCryptoRegistry(session *session.Session) (*s3crypto.CryptoRegistry, error) {
+	kmsClient := kms.New(session)
+
+	cr := s3crypto.NewCryptoRegistry()
+	if err := s3crypto.RegisterKMSWrapWithAnyCMK(cr, kmsClient); err != nil {
+		return nil, err
+	}
+	if err := s3crypto.RegisterKMSContextWrapWithAnyCMK(cr, kmsClient); err != nil {
+		return nil, err
+	}
+	if err := s3crypto.RegisterAESGCMContentCipher(cr); err != nil {
+		return nil, err
+	}
+
+	return cr, nil
 }
 
 func handleError(req *http.Request, err error) (*http.Response, error) {


### PR DESCRIPTION
👋 @DarthSim I didn't hear back about https://github.com/imgproxy/imgproxy/issues/1208, and I needed this feature, so I've added it. Obviously, this PR is missing tests and documentation, but I wanted to first run this by you before putting more work into it. I am also not sure if this repo is watched/maintained as some PRs (like https://github.com/imgproxy/imgproxy/pull/1196) have been open for a while.

Regardless, the changes here fit my use case! I think the only open question I have is _how_ to toggle between a regular client and a decrypted one. There are two choices:

1. Issue one request with the default client; if certain headers suggest that the object is encrypted, issue a second request with the decryption client; or
2. Always use the decryption client. This can be toggled with an env var like `IMGPROXY_S3_USE_CLIENT_ENCRYPTION` (or whatever name you like).

Option 1 offers more flexibility at the cost of another HTTP request; option 2 is best suited for situations like mine, where I know every object in the bucket is encrypted. What do you think?

Will close https://github.com/imgproxy/imgproxy/issues/1208 if merged.