### PR TITLE
Add one-click deploy to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ In terms of security, the massive processing of remote images is a potentially d
 
 Check out our 📑 [Documentation](https://docs.imgproxy.net).
 
+## Deploy
+
+Deploy imgproxy to Dome in [one-click](https://app.trydome.io/signup?package=imgproxy):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=imgproxy)
+
 ## Author
 
 Sergey "[DarthSim](https://github.com/DarthSim)" Alexandrovich

--- a/README.md
+++ b/README.md
@@ -79,12 +79,6 @@ In terms of security, the massive processing of remote images is a potentially d
 
 Check out our 📑 [Documentation](https://docs.imgproxy.net).
 
-## Deploy
-
-Deploy imgproxy to Dome in [one-click](https://app.trydome.io/signup?package=imgproxy):
-
-[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=imgproxy)
-
 ## Author
 
 Sergey "[DarthSim](https://github.com/DarthSim)" Alexandrovich

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -15,6 +15,10 @@ If you don't have docker, you can use Heroku for a quick start.
 
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/DarthSim/imgproxy)
 
+For quick self-hosted option, you can [one-click deploy](https://app.trydome.io/signup?package=imgproxy) with Dome:
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=imgproxy)
+
 Check out our [installation guide](installation.md) for more details and instructions.
 
 In both cases, that's it! No further configuration is needed, but if you want to unleash the full power of imgproxy, read our [configuration guide](configuration.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,6 +34,12 @@ helm upgrade -i --name imgproxy imgproxy/imgproxy
 
 Check out the [chart's README](https://github.com/imgproxy/imgproxy-helm) for more info.
 
+## Dome
+
+Deploy imgproxy to Dome in [one-click](https://app.trydome.io/signup?package=imgproxy):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=imgproxy)
+
 ## Heroku
 
 imgproxy can be deployed to Heroku with the click of a button:


### PR DESCRIPTION
@DarthSim I saw your comment here: https://github.com/imgproxy/imgproxy/issues/1211#issuecomment-1766680977 and thought that we could help provide a cool one-click deploy experience for imgproxy users.

We’ve made the default [one-click deployment](https://app.trydome.io/signup?package=imgproxy) 0.75 CPU cores + 1GB of RAM and it seems to be working fine but could up it to the 2 CPU cores that you recommended for the reasons you stated (multiple global mutexes + round robin LBs potentially sending another job to an already busy instance).

Dome is pretty flexible so it’s possible for users to configure high CPU core counts and still stick with 1GB of RAM or you could also go horizontal with as many 2 CPU cores + 256MB RAM replicas as needed if for example the use case is high concurrency processing of relatively small sized images.  Let me know if you have any additional thoughts.  Thanks.