### PR TITLE
Fix spelling of "project" in airbrake config keys

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -182,9 +182,9 @@ var (
 	SentryEnvironment string
 	SentryRelease     string
 
-	AirbrakeProjecID  int
-	AirbrakeProjecKey string
-	AirbrakeEnv       string
+	AirbrakeProjectID  int
+	AirbrakeProjectKey string
+	AirbrakeEnv        string
 
 	ReportDownloadingErrors bool
 
@@ -373,8 +373,8 @@ func Reset() {
 	SentryEnvironment = "production"
 	SentryRelease = fmt.Sprintf("imgproxy@%s", version.Version)
 
-	AirbrakeProjecID = 0
-	AirbrakeProjecKey = ""
+	AirbrakeProjectID = 0
+	AirbrakeProjectKey = ""
 	AirbrakeEnv = "production"
 
 	ReportDownloadingErrors = true
@@ -590,8 +590,8 @@ func Configure() error {
 	configurators.String(&SentryDSN, "IMGPROXY_SENTRY_DSN")
 	configurators.String(&SentryEnvironment, "IMGPROXY_SENTRY_ENVIRONMENT")
 	configurators.String(&SentryRelease, "IMGPROXY_SENTRY_RELEASE")
-	configurators.Int(&AirbrakeProjecID, "IMGPROXY_AIRBRAKE_PROJECT_ID")
-	configurators.String(&AirbrakeProjecKey, "IMGPROXY_AIRBRAKE_PROJECT_KEY")
+	configurators.Int(&AirbrakeProjectID, "IMGPROXY_AIRBRAKE_PROJECT_ID")
+	configurators.String(&AirbrakeProjectKey, "IMGPROXY_AIRBRAKE_PROJECT_KEY")
 	configurators.String(&AirbrakeEnv, "IMGPROXY_AIRBRAKE_ENVIRONMENT")
 	configurators.Bool(&ReportDownloadingErrors, "IMGPROXY_REPORT_DOWNLOADING_ERRORS")
 	configurators.Bool(&EnableDebugHeaders, "IMGPROXY_ENABLE_DEBUG_HEADERS")

--- a/errorreport/airbrake/airbrake.go
+++ b/errorreport/airbrake/airbrake.go
@@ -16,10 +16,10 @@ var (
 )
 
 func Init() {
-	if len(config.AirbrakeProjecKey) > 0 {
+	if len(config.AirbrakeProjectKey) > 0 {
 		notifier = gobrake.NewNotifierWithOptions(&gobrake.NotifierOptions{
-			ProjectId:   int64(config.AirbrakeProjecID),
-			ProjectKey:  config.AirbrakeProjecKey,
+			ProjectId:   int64(config.AirbrakeProjectID),
+			ProjectKey:  config.AirbrakeProjectKey,
 			Environment: config.AirbrakeEnv,
 		})
 	}


### PR DESCRIPTION
Noticed the "t" was missing.