### PR TITLE
Add support for padding values including zero in imgproxy

### DIFF
--- a/options/processing_options.go
+++ b/options/processing_options.go
@@ -480,9 +480,7 @@ func applyPaddingOption(po *ProcessingOptions, args []string) error {
 		return fmt.Errorf("Invalid padding arguments: %v", args)
 	}
 
-	po.Padding.Enabled = true
-
-	if nArgs > 0 && len(args[0]) > 0 {
+	if nArgs > 0 {
 		if err := parseDimension(&po.Padding.Top, "padding top (+all)", args[0]); err != nil {
 			return err
 		}
@@ -491,28 +489,26 @@ func applyPaddingOption(po *ProcessingOptions, args []string) error {
 		po.Padding.Left = po.Padding.Top
 	}
 
-	if nArgs > 1 && len(args[1]) > 0 {
+	if nArgs > 1 {
 		if err := parseDimension(&po.Padding.Right, "padding right (+left)", args[1]); err != nil {
 			return err
 		}
 		po.Padding.Left = po.Padding.Right
 	}
 
-	if nArgs > 2 && len(args[2]) > 0 {
+	if nArgs > 2 {
 		if err := parseDimension(&po.Padding.Bottom, "padding bottom", args[2]); err != nil {
 			return err
 		}
 	}
 
-	if nArgs > 3 && len(args[3]) > 0 {
+	if nArgs > 3 {
 		if err := parseDimension(&po.Padding.Left, "padding left", args[3]); err != nil {
 			return err
 		}
 	}
 
-	if po.Padding.Top == 0 && po.Padding.Right == 0 && po.Padding.Bottom == 0 && po.Padding.Left == 0 {
-		po.Padding.Enabled = false
-	}
+	po.Padding.Enabled = po.Padding.Top > 0 || po.Padding.Right > 0 || po.Padding.Bottom > 0 || po.Padding.Left > 0
 
 	return nil
 }


### PR DESCRIPTION
### Description

This PR adds support for specifying padding values including zero in imgproxy. Previously, padding values of zero were not accepted, which limited the flexibility of the padding option. Additionally, padding will only be enabled if at least one padding value is greater than zero.

### Changes

1. Modified the `applyPaddingOption` function to correctly handle padding values including zero.
2. Enabled the `po.Padding` flag based on the presence of at least one padding value greater than zero.

### Modified Code

```go
func applyPaddingOption(po *ProcessingOptions, args []string) error {
	nArgs := len(args)

	if nArgs < 1 || nArgs > 4 {
		return fmt.Errorf("Invalid padding arguments: %v", args)
	}

	if nArgs > 0 {
		if err := parseDimension(&po.Padding.Top, "padding top (+all)", args[0]); err != nil {
			return err
		}
		po.Padding.Right = po.Padding.Top
		po.Padding.Bottom = po.Padding.Top
		po.Padding.Left = po.Padding.Top
	}

	if nArgs > 1 {
		if err := parseDimension(&po.Padding.Right, "padding right (+left)", args[1]); err != nil {
			return err
		}
		po.Padding.Left = po.Padding.Right
	}

	if nArgs > 2 {
		if err := parseDimension(&po.Padding.Bottom, "padding bottom", args[2]); err != nil {
			return err
		}
	}

	if nArgs > 3 {
		if err := parseDimension(&po.Padding.Left, "padding left", args[3]); err != nil {
			return err
		}
	}

	// Enable padding only if at least one padding value is greater than 0
	po.Padding.Enabled = po.Padding.Top > 0 || po.Padding.Right > 0 || po.Padding.Bottom > 0 || po.Padding.Left > 0

	return nil
}
