### PR TITLE
Add IMGPROXY_S3_ENDPOINT_USE_PATH_STYLE control UsePathStyle

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -107,6 +107,7 @@ var (
 	S3Enabled                 bool
 	S3Region                  string
 	S3Endpoint                string
+	S3EndpointUsePathStyle    bool
 	S3AssumeRoleArn           string
 	S3AssumeRoleExternalID    string
 	S3MultiRegion             bool
@@ -308,6 +309,7 @@ func Reset() {
 	S3Enabled = false
 	S3Region = ""
 	S3Endpoint = ""
+	S3EndpointUsePathStyle = true
 	S3AssumeRoleArn = ""
 	S3AssumeRoleExternalID = ""
 	S3MultiRegion = false
@@ -539,6 +541,7 @@ func Configure() error {
 	configurators.Bool(&S3Enabled, "IMGPROXY_USE_S3")
 	configurators.String(&S3Region, "IMGPROXY_S3_REGION")
 	configurators.String(&S3Endpoint, "IMGPROXY_S3_ENDPOINT")
+	configurators.Bool(&S3EndpointUsePathStyle, "IMGPROXY_S3_ENDPOINT_USE_PATH_STYLE")
 	configurators.String(&S3AssumeRoleArn, "IMGPROXY_S3_ASSUME_ROLE_ARN")
 	configurators.String(&S3AssumeRoleExternalID, "IMGPROXY_S3_ASSUME_ROLE_EXTERNAL_ID")
 	configurators.Bool(&S3MultiRegion, "IMGPROXY_S3_MULTI_REGION")

--- a/transport/s3/s3.go
+++ b/transport/s3/s3.go
@@ -84,7 +84,7 @@ func New() (http.RoundTripper, error) {
 		}
 		clientOptions = append(clientOptions, func(o *s3.Options) {
 			o.BaseEndpoint = aws.String(endpoint)
-			o.UsePathStyle = true
+			o.UsePathStyle = config.S3EndpointUsePathStyle
 		})
 	}
 


### PR DESCRIPTION
First of all, I would like to thank the authors of imgproxy for their selfless dedication, imgproxy is a good tool platform

When I use Alibaba Cloud OSS, I get the following error:

> Can't download source image: Status: 403; operation error S3: GetObject, https response error StatusCode: 403, RequestID:, HostID: , api error SecondLevelDomainForbidden: Please use virtual hosted style to access

Then I changed **UsePathStyle** to false and it worked. Hence the need to open the control of the **UsePathStyle**