### PR TITLE
Add CookieJar Support for Cookie Passthrough in Redirects

### DIFF
--- a/imagedata/download.go
+++ b/imagedata/download.go
@@ -105,20 +105,8 @@ func initDownloading() error {
 		}
 	}
 
-	var jar http.CookieJar
-	// If CookiePassthrough is enabled in the config, initialize a CookieJar to manage cookies
-	// and allow the client to handle cookies during redirects.
-	if config.CookiePassthrough {
-		var err error
-		jar, err = cookiejar.New(nil)
-		if err != nil {
-			return err
-		}
-	}
-
 	downloadClient = &http.Client{
 		Transport: transport,
-		Jar: jar,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			redirects := len(via)
 			if redirects >= config.MaxRedirects {
@@ -190,8 +178,22 @@ func BuildImageRequest(ctx context.Context, imageURL string, header http.Header,
 }
 
 func SendRequest(req *http.Request) (*http.Response, error) {
+	var client *http.Client
+	if req.URL.Scheme == "http" || req.URL.Scheme == "https" {
+		clientCopy := *downloadClient
+
+		jar, err := cookiejar.New(nil)
+		if err != nil {
+			return nil, err
+		}
+		clientCopy.Jar = jar
+		client = &clientCopy
+	} else {
+		client = downloadClient
+	}
+
 	for {
-		res, err := downloadClient.Do(req)
+		res, err := client.Do(req)
 		if err == nil {
 			return res, nil
 		}

--- a/imagedata/download.go
+++ b/imagedata/download.go
@@ -105,8 +105,20 @@ func initDownloading() error {
 		}
 	}
 
+	var jar http.CookieJar
+	// If CookiePassthrough is enabled in the config, initialize a CookieJar to manage cookies
+	// and allow the client to handle cookies during redirects.
+	if config.CookiePassthrough {
+		var err error
+		jar, err = cookiejar.New(nil)
+		if err != nil {
+			return err
+		}
+	}
+
 	downloadClient = &http.Client{
 		Transport: transport,
+		Jar: jar,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			redirects := len(via)
 			if redirects >= config.MaxRedirects {


### PR DESCRIPTION
This merge request introduces support for cookie management during redirects by adding a `CookieJar` to the `http.Client` when `config.CookiePassthrough` is enabled. When this option is set to `true`, the `CookieJar` is initialized to store and manage cookies across multiple requests, including handling cookie changes on redirects. If `CookiePassthrough` is disabled, the `Jar` remains `nil`, and no cookie management occurs.

Key changes:
- Added a conditional check to initialize `http.CookieJar` based on `config.CookiePassthrough`.
- Ensured the client handles redirects without exceeding the configured maximum number of redirects (`config.MaxRedirects`).
- Improved error handling in case of failure during `CookieJar` initialization.

This feature allows for seamless handling of session-based or cookie-dependent operations during HTTP requests with redirection.