### PR TITLE
allow heix ftype brand for heifs

### DIFF
--- a/imagemeta/heif.go
+++ b/imagemeta/heif.go
@@ -7,14 +7,14 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"slices"
 
 	"github.com/imgproxy/imgproxy/v3/imagetype"
 )
 
 const heifBoxHeaderSize = uint64(8)
 
-var heicBrands = []string{"heic", "heix"}
+var heicBrand = []byte("heic")
+var heixBrand = []byte("heix")
 var avifBrand = []byte("avif")
 var heifPict = []byte("pict")
 
@@ -94,7 +94,7 @@ func heifReadBoxHeader(r io.Reader) (boxType string, boxDataSize uint64, err err
 }
 
 func heifAssignFormat(d *heifData, brand []byte) bool {
-	if slices.Contains(heicBrands, string(brand)) {
+	if bytes.Equal(brand, heicBrand) || bytes.Equal(brand, heixBrand) {
 		d.Format = imagetype.HEIC
 		return true
 	}

--- a/imagemeta/heif.go
+++ b/imagemeta/heif.go
@@ -7,13 +7,14 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"slices"
 
 	"github.com/imgproxy/imgproxy/v3/imagetype"
 )
 
 const heifBoxHeaderSize = uint64(8)
 
-var heicBrand = []byte("heic")
+var heicBrands = []string{"heic", "heix"}
 var avifBrand = []byte("avif")
 var heifPict = []byte("pict")
 
@@ -93,7 +94,7 @@ func heifReadBoxHeader(r io.Reader) (boxType string, boxDataSize uint64, err err
 }
 
 func heifAssignFormat(d *heifData, brand []byte) bool {
-	if bytes.Equal(brand, heicBrand) {
+	if slices.Contains(heicBrands, string(brand)) {
 		d.Format = imagetype.HEIC
 		return true
 	}


### PR DESCRIPTION
We have a number of heic files that imgproxy cannot process with the error

```
Can't download source image: Image is not compatible with heic/avif
```

These heic files seem to be from DSLR cameras, and use the `ftyp` brand `heix` in their box metadata:

```
sandbox/jtomson-imgproxy [allow_heix_ftype] % heif-info -d FILE1.heic
MIME type: image/heic
main brand: heix
compatible brands: mif1, MiHA, miaf, heix
Box: ftyp -----
size: 32   (header size: 8)
major brand: heix
minor version: 0
compatible brands: mif1,MiHA,miaf,heix
```

```
sandbox/jtomson-imgproxy [allow_heix_ftype] % heif-info -d FILE2.heic
MIME type: image/heic
main brand: heix
compatible brands: mif1, heix, miaf, MiHA, jpeg, SHIF
Box: ftyp -----
size: 40   (header size: 8)
major brand: heix
minor version: 0
compatible brands: mif1,heix,miaf,MiHA,jpeg,SHIF
```

`libheif` has supported this `ftyp` since 2020 and imgproxy built locally with this patch can process the files without issue

https://github.com/strukturag/libheif/commit/3cb99d787d93f02eca0aec129b1373fec2e15a78#diff-1dede4959a1188fc7739739647e681aa8f8b3f5d68dcee80286f2b6cb90c28d7R108