### PR TITLE
Introducing imgproxy Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 
 <p align="center">
 <a href="https://github.com/imgproxy/imgproxy/actions"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/imgproxy/imgproxy/on-push.yml?branch=master&label=CI&style=for-the-badge" /></a>
+<a href="https://gurubase.io/g/imgproxy"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20imgproxy%20Guru-006BFF?style=for-the-badge" /></a>
 </p>
 
 ---


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [imgproxy Guru](https://gurubase.io/g/imgproxy) to Gurubase. imgproxy Guru uses the data from this repo and data from the [docs](https://imgproxy.net/blog/) to answer questions by leveraging the LLM.

In this PR, I showcased the "imgproxy Guru", which highlights that imgproxy now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable imgproxy Guru in Gurubase, just let me know that's totally fine.
