### PR TITLE
Set trace status to Error when using OTEL exporter

### DIFF
--- a/metrics/otel/otel.go
+++ b/metrics/otel/otel.go
@@ -25,6 +25,7 @@ import (
 	"go.opentelemetry.io/contrib/propagators/aws/xray"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
@@ -483,7 +484,7 @@ func SendError(ctx context.Context, errType string, err error) {
 			attributes = append(attributes, semconv.ExceptionStacktraceKey.String(stack))
 		}
 	}
-
+	span.SetStatus(codes.Error, err.Error())
 	span.AddEvent(semconv.ExceptionEventName, trace.WithAttributes(attributes...))
 }
 


### PR DESCRIPTION
Hi, 
while implementing OTEL trace export in our infrastructure, I noticed that error traces were not marked as errors and their status was set to OK.

This PR sets the trace status before sending it, as stated [here](https://uptrace.dev/opentelemetry/go-tracing.html#setting-status-code).

Before in datadog traces explorer (we use otel exporter with datadog storage):
![image](https://github.com/user-attachments/assets/c85d7c2b-ca3d-4804-aace-029bd44e2acd)

After in datadog:
![image](https://github.com/user-attachments/assets/17fa42f1-b3d8-4a28-bd57-0ebe898d2cc5)

