### PR TITLE
Fix ld: error: undefined symbol: ceil on FreeBSD

### DIFF
--- a/vips/vips.go
+++ b/vips/vips.go
@@ -3,6 +3,7 @@ package vips
 /*
 #cgo pkg-config: vips
 #cgo CFLAGS: -O3
+#cgo LDFLAGS: -lm
 #include "vips.h"
 */
 import "C"


### PR DESCRIPTION
When building on FreeBSD the compilation errors because it cannot find the math library. This single line links it.