### PR TITLE
Fix question mark handling for non-http URLs

### DIFF
--- a/imagedata/download.go
+++ b/imagedata/download.go
@@ -146,6 +146,7 @@ func BuildImageRequest(ctx context.Context, imageURL string, header http.Header,
 	if !strings.HasPrefix(imageURL, "http://") && !strings.HasPrefix(imageURL, "https://") {
 		imageURL = strings.ReplaceAll(imageURL, "%", "%25")
 		imageURL = strings.ReplaceAll(imageURL, "#", "%23")
+		imageURL = strings.ReplaceAll(imageURL, "?", "%3F")
 	}
 
 	req, err := http.NewRequestWithContext(reqCtx, "GET", imageURL, nil)

--- a/transport/common/common.go
+++ b/transport/common/common.go
@@ -28,8 +28,10 @@ func GetBucketAndKey(u *url.URL) (bucket, key string) {
 	// It's important to revert %23 first because the original URL may also contain %23,
 	// and we don't want to mix them up.
 	bucket = strings.ReplaceAll(bucket, "%23", "#")
+	bucket = strings.ReplaceAll(bucket, "%3F", "?")
 	bucket = strings.ReplaceAll(bucket, "%25", "%")
 	key = strings.ReplaceAll(key, "%23", "#")
+	key = strings.ReplaceAll(key, "%3F", "?")
 	key = strings.ReplaceAll(key, "%25", "%")
 
 	return


### PR DESCRIPTION
Recent releases saw some changes to how special characters are handled in non-HTTP URLs, particularly a special case was added for ```#```. Since local URLs / files may include ```?``` as well (at least on Linux) this needs to be handled as well.