### PR TITLE
add query string passthrough and disable cookie rfc checks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -102,10 +102,12 @@ var (
 	SanitizeSvg        bool
 	AlwaysRasterizeSvg bool
 
-	CookiePassthrough bool
-	CookieBaseURL     string
+	CookiePassthrough   bool
+	CookieDisableChecks bool
+	CookieBaseURL       string
 
-	SourceURLQuerySeparator string
+	SourceURLQuerySeparator   string
+	SourceURLQueryPassthrough bool
 
 	LocalFileSystemRoot string
 
@@ -561,7 +563,10 @@ func Configure() error {
 	configurators.Bool(&DevelopmentErrorsMode, "IMGPROXY_DEVELOPMENT_ERRORS_MODE")
 
 	configurators.Bool(&CookiePassthrough, "IMGPROXY_COOKIE_PASSTHROUGH")
+	configurators.Bool(&CookieDisableChecks, "IMGPROXY_COOKIE_DISABLE_RFC_CHECKS")
 	configurators.String(&CookieBaseURL, "IMGPROXY_COOKIE_BASE_URL")
+
+	configurators.Bool(&SourceURLQueryPassthrough, "IMGPROXY_SOURCE_URL_QUERY_PASSTHROUGH")
 
 	// Can't rely on configurators.String here because it ignores empty values
 	if s, ok := os.LookupEnv("IMGPROXY_SOURCE_URL_QUERY_SEPARATOR"); ok {

--- a/imagedata/download.go
+++ b/imagedata/download.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/imgproxy/imgproxy/v3/config"
+	"github.com/imgproxy/imgproxy/v3/cookies"
 	"github.com/imgproxy/imgproxy/v3/ierrors"
 	"github.com/imgproxy/imgproxy/v3/security"
 
@@ -50,7 +51,7 @@ const msgSourceImageIsUnreachable = "Source image is unreachable"
 
 type DownloadOptions struct {
 	Header    http.Header
-	CookieJar *cookiejar.Jar
+	CookieJar *cookies.PassthroughCookieJar
 }
 
 type ErrorNotModified struct {
@@ -135,7 +136,7 @@ func headersToStore(res *http.Response) map[string]string {
 	return m
 }
 
-func BuildImageRequest(ctx context.Context, imageURL string, header http.Header, jar *cookiejar.Jar) (*http.Request, context.CancelFunc, error) {
+func BuildImageRequest(ctx context.Context, imageURL string, header http.Header, jar *cookies.PassthroughCookieJar) (*http.Request, context.CancelFunc, error) {
 	reqCtx, reqCancel := context.WithTimeout(ctx, time.Duration(config.DownloadTimeout)*time.Second)
 
 	imageURL = transportCommon.EscapeURL(imageURL)

--- a/imagedata/download.go
+++ b/imagedata/download.go
@@ -139,7 +139,9 @@ func headersToStore(res *http.Response) map[string]string {
 func BuildImageRequest(ctx context.Context, imageURL string, header http.Header, jar *cookies.PassthroughCookieJar) (*http.Request, context.CancelFunc, error) {
 	reqCtx, reqCancel := context.WithTimeout(ctx, time.Duration(config.DownloadTimeout)*time.Second)
 
-	imageURL = transportCommon.EscapeURL(imageURL)
+	if !config.SourceURLQueryPassthrough {
+		imageURL = transportCommon.EscapeURL(imageURL)
+	}
 
 	req, err := http.NewRequestWithContext(reqCtx, "GET", imageURL, nil)
 	if err != nil {

--- a/imagedata/download.go
+++ b/imagedata/download.go
@@ -139,9 +139,7 @@ func headersToStore(res *http.Response) map[string]string {
 func BuildImageRequest(ctx context.Context, imageURL string, header http.Header, jar *cookies.PassthroughCookieJar) (*http.Request, context.CancelFunc, error) {
 	reqCtx, reqCancel := context.WithTimeout(ctx, time.Duration(config.DownloadTimeout)*time.Second)
 
-	if !config.SourceURLQueryPassthrough {
-		imageURL = transportCommon.EscapeURL(imageURL)
-	}
+	imageURL = transportCommon.EscapeURL(imageURL)
 
 	req, err := http.NewRequestWithContext(reqCtx, "GET", imageURL, nil)
 	if err != nil {

--- a/options/processing_options.go
+++ b/options/processing_options.go
@@ -1142,8 +1142,10 @@ func parsePathOptions(parts []string, headers http.Header) (*ProcessingOptions, 
 
 	options, urlParts := parseURLOptions(parts)
 
-	if err = applyURLOptions(po, options); err != nil {
-		return nil, "", err
+	if !config.SourceURLQueryPassthrough {
+		if err = applyURLOptions(po, options); err != nil {
+			return nil, "", err
+		}
 	}
 
 	url, extension, err := DecodeURL(urlParts)

--- a/options/processing_options.go
+++ b/options/processing_options.go
@@ -1142,10 +1142,8 @@ func parsePathOptions(parts []string, headers http.Header) (*ProcessingOptions, 
 
 	options, urlParts := parseURLOptions(parts)
 
-	if !config.SourceURLQueryPassthrough {
-		if err = applyURLOptions(po, options); err != nil {
-			return nil, "", err
-		}
+	if err = applyURLOptions(po, options); err != nil {
+		return nil, "", err
 	}
 
 	url, extension, err := DecodeURL(urlParts)
@@ -1189,7 +1187,7 @@ func parsePathPresets(parts []string, headers http.Header) (*ProcessingOptions, 
 	return po, url, nil
 }
 
-func ParsePath(path string, headers http.Header) (*ProcessingOptions, string, error) {
+func ParsePath(path string, headers http.Header, queryString string) (*ProcessingOptions, string, error) {
 	if path == "" || path == "/" {
 		return nil, "", ierrors.New(404, fmt.Sprintf("Invalid path: %s", path), "Invalid URL")
 	}
@@ -1210,6 +1208,10 @@ func ParsePath(path string, headers http.Header) (*ProcessingOptions, string, er
 
 	if err != nil {
 		return nil, "", ierrors.New(404, err.Error(), "Invalid URL")
+	}
+
+	if config.SourceURLQueryPassthrough && len(queryString) > 0 {
+		imageURL += queryString
 	}
 
 	return po, imageURL, nil

--- a/options/url.go
+++ b/options/url.go
@@ -56,6 +56,7 @@ func decodeBase64URL(parts []string) (string, string, error) {
 
 func decodePlainURL(parts []string) (string, string, error) {
 	var format string
+	var unescaped string
 
 	encoded := strings.Join(parts, "/")
 	urlParts := strings.Split(encoded, "@")
@@ -72,9 +73,15 @@ func decodePlainURL(parts []string) (string, string, error) {
 		format = urlParts[1]
 	}
 
-	unescaped, err := url.PathUnescape(urlParts[0])
-	if err != nil {
-		return "", "", fmt.Errorf("Invalid url encoding: %s", encoded)
+	if !config.SourceURLQueryPassthrough {
+		unescapedUrl, err := url.PathUnescape(urlParts[0])
+		if err != nil {
+			return "", "", fmt.Errorf("Invalid url encoding: %s", encoded)
+		}
+
+		unescaped = unescapedUrl
+	} else {
+		unescaped = urlParts[0]
 	}
 
 	return preprocessURL(unescaped), format, nil

--- a/options/url.go
+++ b/options/url.go
@@ -56,7 +56,6 @@ func decodeBase64URL(parts []string) (string, string, error) {
 
 func decodePlainURL(parts []string) (string, string, error) {
 	var format string
-	var unescaped string
 
 	encoded := strings.Join(parts, "/")
 	urlParts := strings.Split(encoded, "@")
@@ -73,15 +72,9 @@ func decodePlainURL(parts []string) (string, string, error) {
 		format = urlParts[1]
 	}
 
-	if !config.SourceURLQueryPassthrough {
-		unescapedUrl, err := url.PathUnescape(urlParts[0])
-		if err != nil {
-			return "", "", fmt.Errorf("Invalid url encoding: %s", encoded)
-		}
-
-		unescaped = unescapedUrl
-	} else {
-		unescaped = urlParts[0]
+	unescaped, err := url.PathUnescape(urlParts[0])
+	if err != nil {
+		return "", "", fmt.Errorf("Invalid url encoding: %s", encoded)
 	}
 
 	return preprocessURL(unescaped), format, nil

--- a/processing_handler.go
+++ b/processing_handler.go
@@ -215,12 +215,11 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
+	queryString := ""
 	path := r.RequestURI
-
-	if !config.SourceURLQueryPassthrough {
-		if queryStart := strings.IndexByte(path, '?'); queryStart >= 0 {
-			path = path[:queryStart]
-		}
+	if queryStart := strings.IndexByte(path, '?'); queryStart >= 0 {
+		queryString = path[queryStart:]
+		path = path[:queryStart]
 	}
 
 	if len(config.PathPrefix) > 0 {
@@ -245,7 +244,7 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 		sendErrAndPanic(ctx, "security", ierrors.New(403, err.Error(), "Forbidden"))
 	}
 
-	po, imageURL, err := options.ParsePath(path, r.Header)
+	po, imageURL, err := options.ParsePath(path, r.Header, queryString)
 	checkErr(ctx, "path_parsing", err)
 
 	errorreport.SetMetadata(r, "Source Image URL", imageURL)

--- a/processing_handler.go
+++ b/processing_handler.go
@@ -216,8 +216,11 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	path := r.RequestURI
-	if queryStart := strings.IndexByte(path, '?'); queryStart >= 0 {
-		path = path[:queryStart]
+
+	if !config.SourceURLQueryPassthrough {
+		if queryStart := strings.IndexByte(path, '?'); queryStart >= 0 {
+			path = path[:queryStart]
+		}
 	}
 
 	if len(config.PathPrefix) > 0 {

--- a/stream.go
+++ b/stream.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"mime"
 	"net/http"
-	"net/http/cookiejar"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -53,7 +52,7 @@ func streamOriginImage(ctx context.Context, reqID string, r *http.Request, rw ht
 	defer metrics.StartStreamingSegment(ctx)()
 
 	var (
-		cookieJar *cookiejar.Jar
+		cookieJar *cookies.PassthroughCookieJar
 		err       error
 	)
 


### PR DESCRIPTION
We found it cumbersome to encode all URLs when they're passed through the imgproxy service. Since this encoding logic would have had to be implemented in every service that generates links for imgproxy, we introduced a new setting that allows us to pass the query string through as is.

Another difficulty is cookie passthrough, by default it checks headers according to the RFC, in our case clients can use different hosts to access the server, and we want to keep it easy for them configuration-wise, we control all the services that receive the cookies anyway, so not a concern for us

I'm not a go-master, but I try