### PR TITLE
Set target hostname to peer.service of the metric.

### DIFF
--- a/processing_handler.go
+++ b/processing_handler.go
@@ -254,7 +254,7 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 
 	parsedURL, err := url.Parse(imageURL)
 	if err == nil {
-		metrics.SetMetadata(ctx, "peer.service", parsedURL.Host)
+		metrics.SetMetadata(ctx, "imgproxy.source_image_origin", parsedURL.Scheme+"://"+parsedURL.Host)
 	}
 
 	err = security.VerifySourceURL(imageURL)

--- a/processing_handler.go
+++ b/processing_handler.go
@@ -252,7 +252,7 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 	metrics.SetMetadata(ctx, "imgproxy.source_image_url", imageURL)
 	metrics.SetMetadata(ctx, "imgproxy.processing_options", po)
 
-	if u, err := url.Parse(imageURL); err == nil {
+	if u, ue := url.Parse(imageURL); ue == nil {
 		metrics.SetMetadata(ctx, "imgproxy.source_image_origin", u.Scheme+"://"+u.Host)
 	}
 

--- a/processing_handler.go
+++ b/processing_handler.go
@@ -252,9 +252,8 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 	metrics.SetMetadata(ctx, "imgproxy.source_image_url", imageURL)
 	metrics.SetMetadata(ctx, "imgproxy.processing_options", po)
 
-	parsedURL, err := url.Parse(imageURL)
-	if err == nil {
-		metrics.SetMetadata(ctx, "imgproxy.source_image_origin", parsedURL.Scheme+"://"+parsedURL.Host)
+	if u, err := url.Parse(imageURL); err == nil {
+		metrics.SetMetadata(ctx, "imgproxy.source_image_origin", u.Scheme+"://"+u.Host)
 	}
 
 	err = security.VerifySourceURL(imageURL)

--- a/processing_handler.go
+++ b/processing_handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"slices"
 	"strconv"
 	"strings"
@@ -250,6 +251,11 @@ func handleProcessing(reqID string, rw http.ResponseWriter, r *http.Request) {
 
 	metrics.SetMetadata(ctx, "imgproxy.source_image_url", imageURL)
 	metrics.SetMetadata(ctx, "imgproxy.processing_options", po)
+
+	parsedURL, err := url.Parse(imageURL)
+	if err == nil {
+		metrics.SetMetadata(ctx, "peer.service", parsedURL.Host)
+	}
 
 	err = security.VerifySourceURL(imageURL)
 	checkErr(ctx, "security", err)


### PR DESCRIPTION
Hello
First of all, thank you for releasing this wonderful software as open source.
I appreciate your efforts.

I have a suggestion/request regarding metrics, so I've submitted a modification proposal.

### Overview

Add the hostname part of image URLs to the metric.

### Motivation

* Want to check processing times by target host rather than by individual URLs
* Want to easily identify problematic target hosts when issues occur with specific hosts

### Details

Currently, the full URL is inserted into metric attributes as `imgproxy.source_image_url`, but we want to record the hostname as well additionally.

For this purpose, I'd like to use `peer.service` as the attribute key, which is commonly used to indicate external services.
This is because services like Datadog already have indexing definitions for this key.

We might also consider adding the same information as `imgproxy.source_image_hostname` (but this PR doesn't include that).

ref: https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/attributes.md#general-remote-service-attributes
