### PR TITLE
feat: add resizeType contain

### DIFF
--- a/options/resize_type.go
+++ b/options/resize_type.go
@@ -10,6 +10,7 @@ const (
 	ResizeFillDown
 	ResizeForce
 	ResizeAuto
+	ResizeContain
 )
 
 var resizeTypes = map[string]ResizeType{
@@ -18,6 +19,7 @@ var resizeTypes = map[string]ResizeType{
 	"fill-down": ResizeFillDown,
 	"force":     ResizeForce,
 	"auto":      ResizeAuto,
+	"contain":   ResizeContain,
 }
 
 func (rt ResizeType) String() string {

--- a/processing/extend.go
+++ b/processing/extend.go
@@ -46,3 +46,22 @@ func extendAspectRatio(pctx *pipelineContext, img *vips.Image, po *options.Proce
 
 	return extendImage(img, width, height, &po.ExtendAspectRatio.Gravity, pctx.dprScale)
 }
+
+func extendContain(pctx *pipelineContext, img *vips.Image, po *options.ProcessingOptions, imgdata *imagedata.ImageData) error {
+	if po.ResizingType != options.ResizeContain {
+		return nil
+	}
+
+	if pctx.targetWidth == 0 || pctx.targetHeight == 0 {
+		return nil
+	}
+
+	imgWidth := img.Width()
+	imgHeight := img.Height()
+
+	if imgWidth >= pctx.targetWidth && imgHeight >= pctx.targetHeight {
+		return nil
+	}
+
+	return extendImage(img, pctx.targetWidth, pctx.targetHeight, &po.Gravity, pctx.dprScale)
+}

--- a/processing/prepare.go
+++ b/processing/prepare.go
@@ -97,7 +97,7 @@ func (pctx *pipelineContext) calcScale(width, height int, po *options.Processing
 			wshrink = hshrink
 		case po.Height == 0 && rt != options.ResizeForce:
 			hshrink = wshrink
-		case rt == options.ResizeFit:
+		case rt == options.ResizeFit || rt == options.ResizeContain:
 			wshrink = math.Max(wshrink, hshrink)
 			hshrink = wshrink
 		case rt == options.ResizeFill || rt == options.ResizeFillDown:
@@ -180,6 +180,11 @@ func (pctx *pipelineContext) calcSizes(widthToScale, heightToScale int, po *opti
 			pctx.resultCropWidth = pctx.targetWidth
 			pctx.resultCropHeight = pctx.targetHeight
 		}
+	} else if po.ResizingType == options.ResizeContain {
+		// For contains mode, we don't crop but extend later
+		// The result size should be the scaled size, not the target size
+		pctx.resultCropWidth = pctx.scaledWidth
+		pctx.resultCropHeight = pctx.scaledHeight
 	} else {
 		pctx.resultCropWidth = pctx.targetWidth
 		pctx.resultCropHeight = pctx.targetHeight

--- a/processing/processing.go
+++ b/processing/processing.go
@@ -30,6 +30,7 @@ var mainPipeline = pipeline{
 	applyFilters,
 	extend,
 	extendAspectRatio,
+	extendContain,
 	padding,
 	fixSize,
 	flatten,


### PR DESCRIPTION
it returns a image in the requested size without croping it. this type acts as the css backround-size type contain

it fills the new whiteSpace with the defined background color