### PR TITLE
Add expected data length to asyncbuffer

### DIFF
--- a/asyncbuffer/reader.go
+++ b/asyncbuffer/reader.go
@@ -32,9 +32,12 @@ func (r *Reader) Seek(offset int64, whence int) (int64, error) {
 		r.pos += offset
 
 	case io.SeekEnd:
-		size, err := r.ab.Wait()
-		if err != nil {
-			return 0, err
+		size := r.ab.dataLen
+		if size <= 0 {
+			var err error
+			if size, err = r.ab.Wait(); err != nil {
+				return 0, err
+			}
 		}
 
 		r.pos = int64(size) + offset

--- a/imagedata/factory.go
+++ b/imagedata/factory.go
@@ -150,7 +150,7 @@ func downloadAsync(ctx context.Context, imageURL string, opts DownloadOptions) (
 		return nil, h, err
 	}
 
-	b := asyncbuffer.New(res.Body, opts.DownloadFinished)
+	b := asyncbuffer.New(res.Body, int(res.ContentLength), opts.DownloadFinished)
 
 	format, err := imagetype.Detect(b.Reader())
 	if err != nil {


### PR DESCRIPTION
Allows seeking from the end without waiting for reader