### PR TITLE
Return 404 for missing GCS objects

### DIFF
--- a/transport/gcs/gcs.go
+++ b/transport/gcs/gcs.go
@@ -187,19 +187,19 @@ func (t transport) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func handleError(req *http.Request, err error) (*http.Response, error) {
-	if errors.Is(err, storage.ErrBucketNotExist) || errors.Is(err, storage.ErrObjectNotExist) {
-		return &http.Response{
-			StatusCode:    http.StatusNotFound,
-			Proto:         "HTTP/1.0",
-			ProtoMajor:    1,
-			ProtoMinor:    0,
-			Header:        http.Header{"Content-Type": {"text/plain"}},
-			ContentLength: int64(len(err.Error())),
-			Body:          io.NopCloser(strings.NewReader(err.Error())),
-			Close:         false,
-			Request:       req,
-		}, nil
+	if !errors.Is(err, storage.ErrBucketNotExist) && !errors.Is(err, storage.ErrObjectNotExist) {
+		return nil, err
 	}
 
-	return nil, err
+	return &http.Response{
+		StatusCode:    http.StatusNotFound,
+		Proto:         "HTTP/1.0",
+		ProtoMajor:    1,
+		ProtoMinor:    0,
+		Header:        http.Header{"Content-Type": {"text/plain"}},
+		ContentLength: int64(len(err.Error())),
+		Body:          io.NopCloser(strings.NewReader(err.Error())),
+		Close:         false,
+		Request:       req,
+	}, nil
 }


### PR DESCRIPTION
## Summary

This change updates the GCS storage integration to use `errors.Is` when checking for errors `storage.ErrBucketNotExist` and `storage.ErrObjectNotExist`.

## Problem

When attempting to fetch an image that does not exist in the configured GCS bucket `imgproxy` currently returns an HTTP 500 Internal Server Error.
In the logs GCS is returning 404 Not Found, but is wrapping the underlying storage error, causing the existing checks to not detect it and for `imgproxy` to not translate the error into a 404.

## Solution

Use `errors.Is` to detect `storage.ErrBucketNotExist` and `storage.ErrObjectNotExist` when they are wrapped.

## Testing

This change was tested against GCS and verified to resolve the issue. After the patch, requests for objects that do not exist correctly return `404` instead of `500`.

## Example Logs

```
client_ip: "4.1.158.110"
error: "Can't download source image: Get "gs://mybucket/myimage.webp": storage: object doesn't exist: googleapi: Error 404: No such object: mybucket/myimage.webp, notFound"
message: "Completed in 34.392892ms /insecure/rt:fill/g:sm/w:400/h:400/plain/gs:%2F%2Fmybucket%2Fmyimage.webp"
method: "GET"
request_id: "7ca52d1f-8170-4eba-94e4-dcdd9d89c7e3"
stack: "/app/imagedata/download.go:195 github.com/imgproxy/imgproxy/v3/imagedata.SendRequest
/app/imagedata/download.go:207 github.com/imgproxy/imgproxy/v3/imagedata.requestImage
/app/imagedata/download.go:272 github.com/imgproxy/imgproxy/v3/imagedata.download
/app/imagedata/image_data.go:135 github.com/imgproxy/imgproxy/v3/imagedata.Download
/app/processing_handler.go:353 main.handleProcessing.func2
/app/processing_handler.go:354 main.handleProcessing
/app/server.go:113 main.buildRouter.withCORS.func1
/app/server.go:170 main.buildRouter.withPanicHandler.func2
/app/server.go:102 main.buildRouter.withMetrics.func3
/app/router/router.go:156 github.com/imgproxy/imgproxy/v3/router.(*Router).ServeHTTP"
status: 500
```