### PR TITLE
Support percent-encoded separators in URL options

### DIFF
--- a/options/processing_options_test.go
+++ b/options/processing_options_test.go
@@ -164,6 +164,44 @@ func (s *ProcessingOptionsTestSuite) TestParseWithArgumentsSeparator() {
 	s.Require().True(po.Enlarge)
 }
 
+func (s *ProcessingOptionsTestSuite) TestParseWithEncodedArgumentsSeparator() {
+	// Test percent-encoded colon (%3A) in option arguments
+	path := "/size%3A100%3A100%3A1/plain/http://images.dev/lorem/ipsum.jpg"
+	po, _, err := ParsePath(path, make(http.Header))
+
+	s.Require().NoError(err)
+
+	s.Require().Equal(100, po.Width)
+	s.Require().Equal(100, po.Height)
+	s.Require().True(po.Enlarge)
+}
+
+func (s *ProcessingOptionsTestSuite) TestParseWithMixedEncodedSeparator() {
+	// Test mix of encoded and literal separators
+	path := "/size:100%3A100:1/plain/http://images.dev/lorem/ipsum.jpg"
+	po, _, err := ParsePath(path, make(http.Header))
+
+	s.Require().NoError(err)
+
+	s.Require().Equal(100, po.Width)
+	s.Require().Equal(100, po.Height)
+	s.Require().True(po.Enlarge)
+}
+
+func (s *ProcessingOptionsTestSuite) TestParseWithEncodedCustomSeparator() {
+	// Test percent-encoded custom separator
+	config.ArgumentsSeparator = ","
+
+	path := "/size%2C100%2C100%2C1/plain/http://images.dev/lorem/ipsum.jpg"
+	po, _, err := ParsePath(path, make(http.Header))
+
+	s.Require().NoError(err)
+
+	s.Require().Equal(100, po.Width)
+	s.Require().Equal(100, po.Height)
+	s.Require().True(po.Enlarge)
+}
+
 // func (s *ProcessingOptionsTestSuite) TestParseURLAllowedSource() {
 // 	config.AllowedSources = []string{"local://", "http://images.dev/"}
 

--- a/options/url_options.go
+++ b/options/url_options.go
@@ -1,6 +1,7 @@
 package options
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/imgproxy/imgproxy/v3/config"
@@ -18,6 +19,11 @@ func parseURLOptions(opts []string) (urlOptions, []string) {
 	urlStart := len(opts) + 1
 
 	for i, opt := range opts {
+		// URL-decode the option segment to support percent-encoded separators
+		if decoded, err := url.PathUnescape(opt); err == nil {
+			opt = decoded
+		}
+
 		args := strings.Split(opt, config.ArgumentsSeparator)
 
 		if len(args) == 1 {


### PR DESCRIPTION
## Summary

- URL-decode option path segments before parsing to support percent-encoded argument separators
- Fixes issue where URLs with `%3A` (encoded colon) fail while literal colons work
- Adds tests for encoded separators with default (`:`) and custom (`,`) separator configurations

Fixes #1581

## Changes

**`options/url_options.go`**: Added URL decoding (`url.PathUnescape`) before splitting option segments by the argument separator. This allows `w%3A1920` to work identically to `w:1920`.

**`options/processing_options_test.go`**: Added 3 new tests:
- `TestParseWithEncodedArgumentsSeparator` - fully encoded separators (`%3A`)
- `TestParseWithMixedEncodedSeparator` - mix of encoded and literal separators
- `TestParseWithEncodedCustomSeparator` - encoded custom separator (`%2C` for comma)

## Test plan

- [x] All existing tests pass
- [x] New tests for percent-encoded separators pass
- [ ] Manual verification: both `w:1920` and `w%3A1920` should produce identical results

🤖 Generated with [Claude Code](https://claude.com/claude-code)