### PR TITLE
fix(CVE-2026-27143): bump minimum Go version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/imgproxy/imgproxy/v3
 
-go 1.26.0
+go 1.26.2
 
 require (
 	cloud.google.com/go/secretmanager v1.16.0


### PR DESCRIPTION
CVE-2026-27143 is a critical (CVSS 9.8) memory corruption vulnerability in Go's compiler (cmd/compile) affecting Go 1.25.0-1.25.8 and 1.26.0-1.26.1. 
Bumping the minimum required Go version to 1.26.2 ensures the project is built with a patched compiler.