### PR TITLE
feat(): add preset label to request_span_duration_seconds Prometheus …

### DIFF
--- a/handlers/processing/handler.go
+++ b/handlers/processing/handler.go
@@ -2,6 +2,7 @@ package processing
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/imgproxy/imgproxy/v4/auximageprovider"
 	"github.com/imgproxy/imgproxy/v4/clientfeatures"
@@ -13,6 +14,7 @@ import (
 	"github.com/imgproxy/imgproxy/v4/httpheaders/conditionalheaders"
 	"github.com/imgproxy/imgproxy/v4/imagedata"
 	"github.com/imgproxy/imgproxy/v4/monitoring"
+	"github.com/imgproxy/imgproxy/v4/options"
 	"github.com/imgproxy/imgproxy/v4/options/keys"
 	optionsparser "github.com/imgproxy/imgproxy/v4/options/parser"
 	"github.com/imgproxy/imgproxy/v4/processing"
@@ -116,10 +118,13 @@ func (h *Handler) newRequest(req *http.Request) (*request, *server.Error) {
 	// get image origin and create monitoring meta object
 	imageOrigin := monitoring.MetaURLOrigin(imageURL)
 
+	preset := strings.Join(options.Get(o, keys.UsedPresets, []string{}), ",")
+
 	mm := monitoring.Meta{
 		monitoring.MetaSourceImageURL:    imageURL,
 		monitoring.MetaSourceImageOrigin: imageOrigin,
 		monitoring.MetaOptions:           o.Map(),
+		monitoring.MetaPreset:            preset,
 	}
 
 	// set error reporting and monitoring context

--- a/handlers/processing/request_methods.go
+++ b/handlers/processing/request_methods.go
@@ -29,7 +29,9 @@ func (r *request) makeImageRequestHeaders() http.Header {
 
 // acquireWorker acquires the processing worker
 func (r *request) acquireWorker() (context.CancelFunc, errctx.Error) {
-	ctx, cancelSpan := r.Monitoring().StartSpan(r.req.Context(), "Queue", nil)
+	ctx, cancelSpan := r.Monitoring().StartSpan(r.req.Context(), "Queue",
+		r.monitoringMeta.Filter(monitoring.MetaPreset),
+	)
 	defer cancelSpan()
 
 	fn, err := r.Workers().Acquire(ctx)
@@ -155,6 +157,7 @@ func (r *request) processImage(
 		"Processing image",
 		r.monitoringMeta.Filter(
 			monitoring.MetaOptions,
+			monitoring.MetaPreset,
 		),
 	)
 	defer cancelSpan()

--- a/monitoring/meta.go
+++ b/monitoring/meta.go
@@ -11,6 +11,7 @@ const (
 	MetaSourceImageURL    = MetaPrefix + "source_image_url"
 	MetaSourceImageOrigin = MetaPrefix + "source_image_origin"
 	MetaOptions           = MetaPrefix + "options"
+	MetaPreset            = MetaPrefix + "preset"
 )
 
 // Meta represents a set of metadata key-value pairs.

--- a/monitoring/prometheus/prometheus.go
+++ b/monitoring/prometheus/prometheus.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/felixge/httpsnoop"
+	"github.com/imgproxy/imgproxy/v4/monitoring"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
@@ -78,7 +79,7 @@ func New(config *Config, stats *stats.Stats) (*Prometheus, error) {
 		Namespace: config.Namespace,
 		Name:      "request_span_duration_seconds",
 		Help:      "A histogram of the request spans duration separated by span name.",
-	}, []string{"span"})
+	}, []string{"span", "preset"})
 
 	p.workers = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: config.Namespace,
@@ -195,8 +196,18 @@ func (p *Prometheus) StartSpan(
 	name string,
 	meta map[string]any,
 ) (context.Context, context.CancelFunc) {
+	var preset string
+	if meta != nil {
+		if v, ok := meta[monitoring.MetaPreset]; ok {
+			preset, _ = v.(string)
+		}
+	}
+
 	return ctx, p.startDuration(
-		p.requestSpanDuration.With(prometheus.Labels{"span": format.FormatSegmentName(name)}),
+		p.requestSpanDuration.With(prometheus.Labels{
+			"span":   format.FormatSegmentName(name),
+			"preset": preset,
+		}),
 	)
 }
 


### PR DESCRIPTION
Add a "preset" label to the request_span_duration_seconds histogram so that span durations can be observed per preset. The applied preset names are extracted from the parsed processing options and passed through the monitoring metadata to the Prometheus StartSpan implementation. When multiple presets are used, the label value is a comma-separated string; when none are used, it is empty.