### PR TITLE
fix(s3): wrap AssumeRoleProvider in CredentialsCache to prevent per-request STS calls

### DIFF
--- a/storage/s3/storage.go
+++ b/storage/s3/storage.go
@@ -67,7 +67,10 @@ func New(config *Config, trans *http.Transport) (*Storage, error) {
 					o.ExternalID = aws.String(config.AssumeRoleExternalID)
 				}
 			})
-		conf.Credentials = creds
+		// Wrap in CredentialsCache so AssumeRole is called once per token
+		// lifetime (~15 min) rather than on every S3 request. Without this,
+		// AssumeRoleProvider has no caching and calls STS on every Retrieve().
+		conf.Credentials = aws.NewCredentialsCache(creds)
 	}
 
 	clientOptions := []func(*s3.Options){


### PR DESCRIPTION
## Context

Closes #1671.

When `IMGPROXY_S3_ASSUME_ROLE_ARN` is configured, imgproxy calls AWS STS `AssumeRole` on every S3 object fetch rather than reusing the token for its lifetime. Under high request volume this exhausts the STS API rate limit (default 15 req/s per account/region), causing S3 fetches to fail with credential errors.

In `storage/s3/storage.go`, the `stscreds.AssumeRoleProvider` was assigned directly to `conf.Credentials` after loading the default config, bypassing the `CredentialsCache` that `awsConfig.LoadDefaultConfig` would otherwise apply automatically. The AWS SDK v2 documentation is explicit:

> A credentials provider implementation can be wrapped with a `CredentialsCache` to cache the credential value retrieved. Without the cache the SDK will attempt to retrieve the credentials for every request.

## Intent

Wrap the `AssumeRoleProvider` in `aws.NewCredentialsCache` so that the STS token is cached for its lifetime (~15 minutes by default) and `AssumeRole` is only called when the token is within the expiry window — reducing calls from one-per-request to approximately one per 15 minutes.

```go
// Before
conf.Credentials = creds

// After
conf.Credentials = aws.NewCredentialsCache(creds)
```