### PR TITLE
Pass through unsupported source types

### DIFF
--- a/handlers/processing/config.go
+++ b/handlers/processing/config.go
@@ -13,6 +13,7 @@ var (
 	IMGPROXY_REPORT_IO_ERRORS          = env.Bool("IMGPROXY_REPORT_IO_ERRORS")
 	IMGPROXY_FALLBACK_IMAGE_HTTP_CODE  = env.Int("IMGPROXY_FALLBACK_IMAGE_HTTP_CODE")
 	IMGPROXY_ENABLE_DEBUG_HEADERS      = env.Bool("IMGPROXY_ENABLE_DEBUG_HEADERS")
+	IMGPROXY_PASS_UNSUPPORTED_TYPE     = env.Bool("IMGPROXY_PASS_UNSUPPORTED_TYPE")
 )
 
 // Config represents handler config
@@ -21,6 +22,7 @@ type Config struct {
 	ReportIOErrors          bool // Whether to report IO errors
 	FallbackImageHTTPCode   int  // Fallback image HTTP status code
 	EnableDebugHeaders      bool // Whether to enable debug headers
+	PassUnsupportedType     bool // Whether to pass original image data for unsupported formats
 }
 
 // NewDefaultConfig creates a new configuration with defaults
@@ -42,6 +44,7 @@ func LoadConfigFromEnv(c *Config) (*Config, error) {
 		IMGPROXY_REPORT_IO_ERRORS.Parse(&c.ReportIOErrors),
 		IMGPROXY_FALLBACK_IMAGE_HTTP_CODE.Parse(&c.FallbackImageHTTPCode),
 		IMGPROXY_ENABLE_DEBUG_HEADERS.Parse(&c.EnableDebugHeaders),
+		IMGPROXY_PASS_UNSUPPORTED_TYPE.Parse(&c.PassUnsupportedType),
 	)
 
 	return c, err

--- a/handlers/processing/request.go
+++ b/handlers/processing/request.go
@@ -108,6 +108,11 @@ func (r *request) execute() *server.Error {
 
 	// Check if image supports load from origin format
 	if !vips.SupportsLoad(originData.Format()) {
+		if r.config.PassUnsupportedType {
+			r.opts.DeleteByPrefix("")
+			r.opts.Set(keys.SkipProcessing, "true")
+			return r.respondWithImage(statusCode, originData)
+		}
 		return server.NewError(
 			handlers.NewCantLoadError(ctx, originData.Format()),
 			handlers.ErrCategoryPathParsing,

--- a/handlers/processing/request_methods.go
+++ b/handlers/processing/request_methods.go
@@ -59,9 +59,10 @@ func (r *request) makeDownloadOptions(
 	}
 
 	return imagedata.DownloadOptions{
-		Header:         h,
-		MaxSrcFileSize: r.Security().MaxSrcFileSize(r.opts),
-		CookieJar:      jar,
+		Header:             h,
+		MaxSrcFileSize:     r.Security().MaxSrcFileSize(r.opts),
+		CookieJar:          jar,
+		PassUnsupportedType: r.config != nil && r.config.PassUnsupportedType,
 	}, nil
 }
 

--- a/imagedata/download.go
+++ b/imagedata/download.go
@@ -12,10 +12,11 @@ var (
 )
 
 type DownloadOptions struct {
-	Header           http.Header
-	CookieJar        http.CookieJar
-	MaxSrcFileSize   int
-	DownloadFinished context.CancelFunc
+	Header              http.Header
+	CookieJar           http.CookieJar
+	MaxSrcFileSize      int
+	DownloadFinished    context.CancelFunc
+	PassUnsupportedType bool
 }
 
 // RedirectAllRequestsTo TODO: get rid of this global variable

--- a/imagedata/factory.go
+++ b/imagedata/factory.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"io"
 	"net/http"
 	"os"
@@ -172,8 +173,9 @@ func (f *Factory) DownloadAsync(
 	ct := res.Header.Get(httpheaders.ContentType)
 	ext := strings.ToLower(filepath.Ext(res.Request.URL.Path))
 
+	var unknownFormatErr imagetype.UnknownFormatError
 	format, err := imagetype.Detect(b.Reader(), ct, ext)
-	if err != nil {
+	if err != nil && !(opts.PassUnsupportedType && errors.As(err, &unknownFormatErr)) {
 		b.Close()
 		req.Cancel()
 		return nil, h, wrapDownloadError(err, desc)

--- a/imagedata/image_data_test.go
+++ b/imagedata/image_data_test.go
@@ -236,6 +236,29 @@ func (s *ImageDataTestSuite) TestDownloadInvalidImage() {
 	s.Require().Nil(imgdata)
 }
 
+func (s *ImageDataTestSuite) TestAllowDownloadNoImage() {
+	body := []byte("text")
+
+	s.testServer().
+		SetBody(body).
+		SetHeaders(
+			httpheaders.ContentType, "text/plain",
+			httpheaders.ContentLength, strconv.Itoa(len(body)),
+		)
+
+	imgdata, _, err := s.factory().DownloadAsync(
+		context.Background(),
+		s.testServer().URL(),
+		"Test no image",
+		imagedata.DownloadOptions{PassUnsupportedType: true},
+	)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(imgdata)
+	s.Require().Equal(imagetype.Unknown, imgdata.Format())
+	s.Require().True(testutil.ReadersEqual(s.T(), bytes.NewReader(body), imgdata.Reader()))
+}
+
 func (s *ImageDataTestSuite) TestDownloadSourceAddressNotAllowed() {
 	s.fetcherCfg().Transport.HTTP.AllowLoopbackSourceAddresses = false
 


### PR DESCRIPTION
Adds `IMGPROXY_PASS_UNSUPPORTED_TYPE` configuration option.

When **enabled**, unsupported source types are returned as-is instead of responding with 422.

Includes tests covering the new behavior.

Resolves #1683
