### PR TITLE
fix: gzip response uses the compressed length in async download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.0.12] - TBA
+### Fixed
+- Fixed truncated source image downloads when origins return gzip-compressed responses.
+
 ## [4.0.11] - 2026-07-02
 ### Fixed
 - (pro) Non-essential cache errors are no longer reported.

--- a/fetcher/request.go
+++ b/fetcher/request.go
@@ -170,7 +170,11 @@ func wrapGzipBody(res *http.Response) error {
 			Reader: gzipBody,
 			r:      res.Body,
 		}
+		// Content-Length describes the compressed body and is no longer valid.
 		res.Header.Del(httpheaders.ContentEncoding)
+		res.Header.Del(httpheaders.ContentLength)
+		res.ContentLength = -1
+		res.Uncompressed = true
 	}
 
 	return nil

--- a/fetcher/request_test.go
+++ b/fetcher/request_test.go
@@ -1,0 +1,58 @@
+package fetcher_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/imgproxy/imgproxy/v4/fetcher"
+	"github.com/imgproxy/imgproxy/v4/httpheaders"
+)
+
+func TestFetchGzipResponseMetadata(t *testing.T) {
+	source := []byte("gzip response body")
+	compressed := new(bytes.Buffer)
+
+	enc := gzip.NewWriter(compressed)
+	_, err := enc.Write(source)
+	require.NoError(t, err)
+	require.NoError(t, enc.Close())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(httpheaders.ContentEncoding, "gzip")
+		w.Header().Set(httpheaders.ContentLength, strconv.Itoa(compressed.Len()))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(compressed.Bytes())
+	}))
+	defer server.Close()
+
+	config := fetcher.NewDefaultConfig()
+	config.Transport.HTTP.AllowLoopbackSourceAddresses = true
+
+	f, err := fetcher.New(&config)
+	require.NoError(t, err)
+
+	req, err := f.BuildRequest(context.Background(), server.URL, nil, nil)
+	require.NoError(t, err)
+	defer req.Cancel()
+
+	res, err := req.Fetch()
+	require.NoError(t, err)
+	defer res.Body.Close()
+
+	require.Equal(t, int64(-1), res.ContentLength)
+	require.Empty(t, res.Header.Get(httpheaders.ContentEncoding))
+	require.Empty(t, res.Header.Get(httpheaders.ContentLength))
+	require.True(t, res.Uncompressed)
+
+	body, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	require.Equal(t, source, body)
+}

--- a/imagedata/image_data_test.go
+++ b/imagedata/image_data_test.go
@@ -285,6 +285,37 @@ func (s *ImageDataTestSuite) TestDownloadGzip() {
 	s.Require().Equal(imagetype.JPEG, imgdata.Format())
 }
 
+func (s *ImageDataTestSuite) TestDownloadAsyncGzip() {
+	buf := new(bytes.Buffer)
+
+	enc := gzip.NewWriter(buf)
+	_, err := enc.Write(s.data)
+	s.Require().NoError(err)
+	err = enc.Close()
+	s.Require().NoError(err)
+
+	s.testServer().
+		SetBody(buf.Bytes()).
+		SetHeaders(
+			httpheaders.ContentEncoding, "gzip",
+			httpheaders.ContentLength, strconv.Itoa(buf.Len()),
+		)
+
+	imgdata, _, err := s.factory().DownloadAsync(
+		context.Background(), s.testServer().URL(), "Test image", imagedata.DownloadOptions{},
+	)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(imgdata)
+	defer imgdata.Close()
+
+	size, err := imgdata.Size()
+	s.Require().NoError(err)
+	s.Require().Equal(len(s.data), size)
+	s.Require().True(testutil.ReadersEqual(s.T(), bytes.NewReader(s.data), imgdata.Reader()))
+	s.Require().Equal(imagetype.JPEG, imgdata.Format())
+}
+
 func (s *ImageDataTestSuite) TestFromFile() {
 	imgdata, err := s.factory().NewFromPath("../testdata/test1.jpg")
 


### PR DESCRIPTION
When an origin unexpectedly returns gzip content,
wrapGzipBody decodes automatically but preserves
the original content length, which is used to 
limit reads to that size.

Since body is decompressed now:
* if compressed body is smaller, image is silently truncated
* if larger, download reports UnexpectedEOF

After decompression, remove content-length header,
set content length unknown and response uncompressed.

Related to #1497