### PR TITLE
fix: Content-Length being ignored for object storage responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.0.12] - TBA
+### Fixed
+- Fixed the `Content-Length` header being ignored for S3, Google Cloud Storage, Azure Blob Storage, and Swift responses.
+
 ## [4.0.11] - 2026-07-02
 ### Fixed
 - (pro) Non-essential cache errors are no longer reported.

--- a/storage/reader.go
+++ b/storage/reader.go
@@ -101,7 +101,7 @@ func (r *ObjectReader) ContentLength() int64 {
 	h := r.Headers.Get(httpheaders.ContentLength)
 	if len(h) > 0 {
 		p, err := strconv.ParseInt(h, 10, 64)
-		if err != nil {
+		if err == nil {
 			return p
 		}
 	}

--- a/storage/reader_test.go
+++ b/storage/reader_test.go
@@ -1,0 +1,36 @@
+package storage_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/imgproxy/imgproxy/v4/httpheaders"
+	"github.com/imgproxy/imgproxy/v4/storage"
+)
+
+func TestObjectReaderContentLength(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   int64
+	}{
+		{name: "valid header", header: "12345", want: 12345},
+		{name: "invalid header", header: "not-a-number", want: -1},
+		{name: "no header", header: "", want: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := make(http.Header)
+			if len(tt.header) > 0 {
+				h.Set(httpheaders.ContentLength, tt.header)
+			}
+
+			r := storage.NewObjectOK(h, http.NoBody)
+
+			require.Equal(t, tt.want, r.ContentLength())
+		})
+	}
+}


### PR DESCRIPTION
`ObjectReader.ContentLength()` has an inverted error check, so it throws away a successfully parsed `Content-Length` and returns `-1`.

https://github.com/imgproxy/imgproxy/blob/faf382077474eee3c406fa85e8007d340619be12/storage/reader.go#L96-L110

```go
p, err := strconv.ParseInt(h, 10, 64)
if err != nil {
    return p
}
```

On success `err` is nil, so `p` is dropped and the function falls through to `return -1`. On failure it returns `p`, which is `0` for a syntax error. Since every object storage backend reports the size through the `Content-Length` header and leaves the `contentLength` field at `-1`, `res.ContentLength` is always `-1` for S3, Google Cloud Storage, Azure Blob Storage and Swift.

That disables the up-front `Content-Length > IMGPROXY_MAX_SRC_FILE_SIZE` check in `limitResponseSize` for those sources, so an oversized object is streamed and only cut off mid-download by the hard limit reader instead of being rejected before the body is read. It also stops the async buffer from noticing a truncated response and skips the sync download's buffer preallocation.

The fix returns the value when parsing succeeds:

```go
if err == nil {
    return p
}
```

An unparseable header still falls through to `-1` (unknown) instead of `0`.

I added `storage/reader_test.go` covering a valid header, an invalid header and no header. Before the fix the valid case returned `-1` and the invalid case returned `0`; after it they return the parsed length and `-1`. `go test ./storage/...` and `golangci-lint run` pass, and there is a CHANGELOG entry under Fixed.

Fixes #1700 