### PR TITLE
ci: remove the continue-on-error that disables the Fail fast step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,6 @@ jobs:
           tidy-checks: "-*" # disable clang-tidy
 
       - name: Fail fast
-        continue-on-error: true # TODO: remove this line in the future
         if: steps.linter.outputs.checks-failed > 0
         run: exit 1
 


### PR DESCRIPTION
Hi, and thanks for imgproxy.

This is really just acting on a note you left yourselves.

In `.github/workflows/ci.yml` there is a step whose entire job is to fail the build when the C++ linter found problems:

```yaml
      - name: Fail fast
        continue-on-error: true # TODO: remove this line in the future
        if: steps.linter.outputs.checks-failed > 0
        run: exit 1
```

With `continue-on-error: true`, the `exit 1` is swallowed, so the step's only purpose cannot take effect — the job passes whatever the linter found. I checked the file's history through the contents API: the line and its TODO have been there since at least **2024-10-23**, which is coming up on two years.

This PR removes that one line, which is what the TODO asks for.

One thing worth checking before merging, and the reason I would not be surprised if you want to wait: if `master` currently has clang-format or clang-tidy findings, this will start failing CI until they are cleared. I could not tell from outside whether `checks-failed` is currently zero. If it is not, the TODO is presumably still deliberate and this PR is premature — in which case please just close it, no hard feelings, or say the word and I will look at what is outstanding instead.

Nothing else in the workflow is touched; it is a single deleted line.

Disclosure: I used AI assistance to help spot this and prepare the change, and I checked the step and its history myself.
