### PR TITLE
fix: preserve the recovered value when logging non-error panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [4.0.13] - TBA
 ## Fixed
 - Fixed inconsistent environment variable names between the code and documentation (`IMGPROXY_AIRBRAKE_ENVIRONMENT`, `IMGPROXY_S3_USE_DECRYPTION_CLIENT`, `IMGPROXY_USE_LAST_MODIFIED` and `IMGPROXY_USE_ETAG`).
+- Fixed recovered non-error panics still being logged and reported as `panic: <nil>` instead of the actual panic value.
 
 ## [4.0.12] - 2026-07-29
 ### Fixed

--- a/server/middlewares.go
+++ b/server/middlewares.go
@@ -79,7 +79,7 @@ func (r *Router) WithPanic(h RouteHandler) RouteHandler {
 			// let's recover error value from panic if it has panicked with error
 			err, ok := rerr.(error)
 			if !ok {
-				err = fmt.Errorf("panic: %v", err) //nolint:errorlint // err here is not an error, most likely plain string
+				err = fmt.Errorf("panic: %v", rerr)
 			}
 
 			retErr = NewError(errctx.WrapWithStackSkip(err, 1), errCategoryUnexpected)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/imgproxy/imgproxy/v4/httpheaders"
 	"github.com/imgproxy/imgproxy/v4/monitoring"
 	"github.com/imgproxy/imgproxy/v4/server"
+	"github.com/imgproxy/imgproxy/v4/server/responsewriter"
 	"github.com/imgproxy/imgproxy/v4/testutil"
 )
 
@@ -270,6 +271,26 @@ func (s *ServerTestSuite) TestIntoPanicWithNonError() {
 	})
 
 	s.Equal(http.StatusInternalServerError, rw.Code)
+}
+
+func (s *ServerTestSuite) TestIntoPanicWithNonErrorPreservesValue() {
+	rwCfg := responsewriter.NewDefaultConfig()
+	rwf, err := responsewriter.NewFactory(&rwCfg)
+	s.Require().NoError(err)
+
+	handler := s.router().WithPanic(
+		func(reqID string, rw server.ResponseWriter, r *http.Request) *server.Error {
+			panic("string panic")
+		},
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	rww := rwf.NewWriter(httptest.NewRecorder())
+
+	retErr := handler("req-id", rww, req)
+
+	s.Require().NotNil(retErr)
+	s.Contains(retErr.Err.Error(), "string panic")
 }
 
 func (s *ServerTestSuite) mockHandler(reqID string, rw server.ResponseWriter, r *http.Request) *server.Error {


### PR DESCRIPTION
Follow-up to the fix for #1705. That change swapped `%w` for `%v`, which removed the `%!w()` artifact, but the recovered value is still dropped on the non-error branch, so these panics now log `panic: <nil>`.

https://github.com/imgproxy/imgproxy/blob/ed78652c4a5d08c4c712c35d45450c95c1b2487a/server/middlewares.go#L79-L85

```go
err, ok := rerr.(error)
if !ok {
    err = fmt.Errorf("panic: %v", err) //nolint:errorlint // err here is not an error, most likely plain string
}
```

On this branch the type assertion failed, so `err` is the nil zero value of `error`; it is `rerr` that holds the recovered value (a plain string, for example). So `fmt.Errorf("panic: %v", err)` formats `<nil>`, and the actual message is still lost before it reaches `LogResponse` and the reporters.

Formatting the recovered value fixes it, and also makes the `//nolint` unnecessary, `rerr` is `any`, so `errorlint` does not flag it:

```go
if !ok {
    err = fmt.Errorf("panic: %v", rerr)
}
```

I added `TestIntoPanicWithNonErrorPreservesValue`: it drives `WithPanic` with `panic("string panic")` and asserts the recovered error carries the value. On the current `version/4.0` it fails with `"panic: <nil>" does not contain "string panic"`; with `rerr` it passes. `go test ./server/...` and `golangci-lint run` pass, and there is a CHANGELOG entry under Fixed.