### PR TITLE
Fix IMGPROXY_ENABLE_CLIENT_HINTS never being parsed from env

### DIFF
--- a/clientfeatures/config.go
+++ b/clientfeatures/config.go
@@ -45,6 +45,7 @@ func LoadConfigFromEnv(c *Config) (*Config, error) {
 		IMGPROXY_ENFORCE_AVIF.Parse(&c.EnforceAvif),
 		IMGPROXY_AUTO_JXL.Parse(&c.AutoJxl),
 		IMGPROXY_ENFORCE_JXL.Parse(&c.EnforceJxl),
+		IMGPROXY_ENABLE_CLIENT_HINTS.Parse(&c.EnableClientHints),
 	)
 
 	return c, err

--- a/clientfeatures/config_test.go
+++ b/clientfeatures/config_test.go
@@ -1,0 +1,35 @@
+package clientfeatures_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/imgproxy/imgproxy/v4/clientfeatures"
+)
+
+func TestEnableClientHintsParsedTrue(t *testing.T) {
+	t.Setenv("IMGPROXY_ENABLE_CLIENT_HINTS", "true")
+
+	cfg, err := clientfeatures.LoadConfigFromEnv(nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.True(t, cfg.EnableClientHints)
+}
+
+func TestEnableClientHintsParsedFalseByDefault(t *testing.T) {
+	cfg, err := clientfeatures.LoadConfigFromEnv(nil)
+
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+	require.False(t, cfg.EnableClientHints)
+}
+
+func TestEnableClientHintsParsedInvalidValue(t *testing.T) {
+	t.Setenv("IMGPROXY_ENABLE_CLIENT_HINTS", "not-a-bool")
+
+	_, err := clientfeatures.LoadConfigFromEnv(nil)
+
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Fixes #1709.

`clientfeatures/config.go`'s `LoadConfigFromEnv()` declared the
`IMGPROXY_ENABLE_CLIENT_HINTS` env var descriptor but never called `.Parse()` on it,
unlike every sibling flag (`AutoWebp`, `EnforceWebp`, `AutoAvif`, `EnforceAvif`,
`AutoJxl`, `EnforceJxl`). As a result `Config.EnableClientHints` always stayed at its
zero value (`false`), so `Detector.Features()` always short-circuited and imgproxy
never honored `Width`/`DPR`/`Sec-CH-Width`/`Sec-CH-DPR` request headers and never sent
the `Vary` header, regardless of the env var's value.

The fix adds the missing `IMGPROXY_ENABLE_CLIENT_HINTS.Parse(&c.EnableClientHints)`
call to the `errors.Join(...)` block in `LoadConfigFromEnv`.

## Changes

- `clientfeatures/config.go`: add the missing `.Parse()` call.
- `clientfeatures/config_test.go` (new): regression tests covering
  `IMGPROXY_ENABLE_CLIENT_HINTS=true`, the unset default (`false`), and an invalid
  value producing an error.

## Test plan

- [x] `./run test ./clientfeatures/...` — new tests pass, existing suite unaffected.
- [x] `./run lint-go` and `./run lint-clang` — 0 issues.
- [x] Built `docker/Dockerfile` locally and reproduced the issue's repro steps against
      the fixed image:
  - `Vary: Sec-Ch-Dpr, Dpr, Sec-Ch-Width, Width` is now present.
  - A request with `Width: 200` and no explicit URL width now returns
    `Content-Length: 5969`, matching an explicit `resize:fit:200:0` request, versus
    `Content-Length: 59187` without the header — confirming Client Hints resizing now
    works end-to-end.