### PR TITLE
Fix panic on malformed request paths that reduce to an empty path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.0.14] - TBA
+### Fixed
+- Fixed a panic on certain malformed request paths (such as a trailing double slash) that returned a 500 error instead of a proper 4xx response.
+
 ## [4.0.13] - 2026-08-18
 ## Changed
 - Updated dependencies.

--- a/handlers/path.go
+++ b/handlers/path.go
@@ -33,6 +33,9 @@ func SplitPathSignature(r *http.Request) (string, string, error) {
 
 	// restore broken slashes in the path
 	path = RedenormalizePath(path)
+	if len(path) == 0 {
+		return "", "", NewInvalidPathError(r.Context(), path)
+	}
 
 	return path, signature, nil
 }

--- a/handlers/path_test.go
+++ b/handlers/path_test.go
@@ -95,6 +95,13 @@ func (s *PathTestSuite) TestParsePath() {
 			expectedSig:   "",
 			expectedError: true,
 		},
+		{
+			name:          "EmptyPathAfterRedenormalization",
+			requestPath:   "/dummy_signature//",
+			expectedPath:  "",
+			expectedSig:   "",
+			expectedError: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/security/signature.go
+++ b/security/signature.go
@@ -42,7 +42,7 @@ func signatureFor(str string, key, salt []byte, signatureSize int) []byte {
 
 	// It's supposed that path starts with '/'. However, if and input path comes with the
 	// leading slash split, let's re-add it here.
-	if str[0] != '/' {
+	if len(str) == 0 || str[0] != '/' {
 		mac.Write([]byte{'/'})
 	}
 

--- a/security/signature_test.go
+++ b/security/signature_test.go
@@ -69,6 +69,11 @@ func (s *SignatureTestSuite) TestVerifySignatureMultiplePairs() {
 	s.Require().Error(err)
 }
 
+func (s *SignatureTestSuite) TestVerifySignatureEmptyPath() {
+	err := s.checker().VerifySignature(s.T().Context(), "oWaL7QoW5TsgbuiS9-5-DI8S3Ibbo1gdB2SteJh3a20", "")
+	s.Require().Error(err)
+}
+
 func (s *SignatureTestSuite) TestVerifySignatureTrusted() {
 	s.config().TrustedSignatures = []string{"truested"}
 


### PR DESCRIPTION
Fixes #1712 

### The bug

A request whose path reduces to an empty string after redenormalization (for example a trailing `//`, `GET /<signature>//`) panics with `index out of range [0] with length 0` in `signatureFor`, which is recovered as a 500 and reported to the error tracker on every request.

`SplitPathSignature` guards against an empty path, but the guard runs before `RedenormalizePath`, and `RedenormalizePath("/")` returns `""`. The empty path then reaches `signatureFor`, which indexes `str[0]` to decide whether to re-add a leading slash.

It only triggers when URL signing is enabled (with no keys, `VerifySignature` returns before `signatureFor`), but the panic is on the pre-validation path, so no valid signature is needed.

### The fix

Two small changes:

1. `SplitPathSignature` re-checks for an empty path after `RedenormalizePath` and returns `NewInvalidPathError`, so the request gets a proper 4xx invalid-path error instead of reaching signature verification. This completes the existing empty-path guard.
2. `signatureFor` guards `len(str) == 0` before `str[0]`, so the sink cannot panic on an empty path regardless of caller (defense in depth, in the spirit of the existing "re-add the leading slash" logic).

### Tests

- `handlers/path_test.go`: `TestParsePath` gains an `EmptyPathAfterRedenormalization` case (`GET /dummy_signature//`), asserting an error is returned. Fails on the current code (returns an empty path, no error), passes with the fix.
- `security/signature_test.go`: `TestVerifySignatureEmptyPath` calls `VerifySignature` with keys configured and an empty path. Panics on the current code, returns an "Invalid signature" error with the fix.

Verified locally: 
- `go test ./handlers/ ./security/` pass, 
- `gofmt` clean, 
- `golangci-lint` (v2.11.1) reports 0 issues. 
- Changelog entry added under `## [4.0.14] - TBA`.