### PR TITLE
docs: fix typo forwared -> forwarded

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -18,7 +18,7 @@ go tool lefthook install
 
 You can use [`air`](https://github.com/air-verse/air) for hot-reloading during development. Simply run: `go tool air`.
 
-Port `8081` is forwared to the host.
+Port `8081` is forwarded to the host.
 
 # Test images
 


### PR DESCRIPTION
Corrects a single misspelling of `forwared` in `.devcontainer/README.md`.

Documentation only, no behaviour change.