### PR TITLE
Fix IMGPROXY_GRACEFUL_STOP_TIMEOUT not defaulting to 2x IMGPROXY_TIMEOUT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.0.15] - TBA
+### Fixed
+- `IMGPROXY_GRACEFUL_STOP_TIMEOUT` now defaults to twice `IMGPROXY_TIMEOUT` again, as documented. This had regressed to a static 20s default in the 4.x config rewrite.
+
 ## [4.0.14] - 2026-08-24
 ### Changed
 - Updated dependencies.

--- a/server/config.go
+++ b/server/config.go
@@ -93,14 +93,21 @@ func LoadConfigFromEnv(c *Config) (*Config, error) {
 	port := -1
 	bind := ""
 
+	timeoutErr := IMGPROXY_TIMEOUT.Parse(&c.RequestTimeout)
+
+	// The graceful stop timeout defaults to twice the request timeout, so it
+	// must be derived after IMGPROXY_TIMEOUT is resolved but before
+	// IMGPROXY_GRACEFUL_STOP_TIMEOUT is applied as an explicit override.
+	c.GracefulStopTimeout = c.RequestTimeout * 2
+
 	err := errors.Join(
 		rwErr,
+		timeoutErr,
 		PORT.Parse(&port),
 		IMGPROXY_BIND.Parse(&bind),
 		IMGPROXY_NETWORK.Parse(&c.Network),
 		IMGPROXY_PATH_PREFIX.Parse(&c.PathPrefix),
 		IMGPROXY_MAX_CLIENTS.Parse(&c.MaxClients),
-		IMGPROXY_TIMEOUT.Parse(&c.RequestTimeout),
 		IMGPROXY_READ_REQUEST_TIMEOUT.Parse(&c.ReadRequestTimeout),
 		IMGPROXY_KEEP_ALIVE_TIMEOUT.Parse(&c.KeepAliveTimeout),
 		IMGPROXY_GRACEFUL_STOP_TIMEOUT.Parse(&c.GracefulStopTimeout),

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -1,0 +1,57 @@
+package server_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/imgproxy/imgproxy/v4/server"
+)
+
+func TestLoadConfigFromEnvGracefulStopTimeout(t *testing.T) {
+	tests := []struct {
+		name                string
+		timeout             string
+		gracefulStopTimeout string
+		expected            time.Duration
+	}{
+		{
+			name:     "Defaults",
+			expected: 20 * time.Second,
+		},
+		{
+			name:     "TimeoutChangesDefault",
+			timeout:  "30",
+			expected: 60 * time.Second,
+		},
+		{
+			name:                "ExplicitGracefulStopTimeoutOverridesDefault",
+			timeout:             "30",
+			gracefulStopTimeout: "5",
+			expected:            5 * time.Second,
+		},
+		{
+			name:                "ExplicitGracefulStopTimeoutWithoutTimeout",
+			gracefulStopTimeout: "5",
+			expected:            5 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.timeout != "" {
+				t.Setenv("IMGPROXY_TIMEOUT", tt.timeout)
+			}
+			if tt.gracefulStopTimeout != "" {
+				t.Setenv("IMGPROXY_GRACEFUL_STOP_TIMEOUT", tt.gracefulStopTimeout)
+			}
+
+			c := server.NewDefaultConfig()
+			_, err := server.LoadConfigFromEnv(&c)
+			require.NoError(t, err)
+
+			require.Equal(t, tt.expected, c.GracefulStopTimeout)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1720. `IMGPROXY_GRACEFUL_STOP_TIMEOUT` no longer defaults to twice `IMGPROXY_TIMEOUT` in the 4.x line — it was hardcoded to a static 20s default in `NewDefaultConfig()`, disconnected from `RequestTimeout`. This regresses the documented behaviour from 3.30.0 (see `CHANGELOG.md` `[3.30.0] - 2025-09-17`) and both the 4.x and 3.31.x configuration docs, which state the default is `2 * IMGPROXY_TIMEOUT`.

**Note on assumption:** this PR assumes the docs/changelog are the intended behaviour and the 4.x code is the regression. If the static 20s default in 4.x was actually an intentional change, the correct fix would instead be a documentation update (removing the "2x timeout" claim) rather than this code change — happy to pivot if a maintainer says that's the case.

## Changes

- `server/config.go`: `IMGPROXY_TIMEOUT` is now parsed into `RequestTimeout` before the `GracefulStopTimeout` default is computed, so the default is `RequestTimeout * 2` (mirroring the 3.31.x `Configure()` ordering: `GracefulStopTimeout = Timeout * 2` before the `IMGPROXY_GRACEFUL_STOP_TIMEOUT` override is applied). Since `errors.Join`'s arguments are all evaluated before the call, the `IMGPROXY_TIMEOUT` parse was pulled out of the `errors.Join(...)` argument list into its own statement so the derived-default assignment could be sequenced in between it and the rest of the joined parses.
- `server/config_test.go`: added `TestLoadConfigFromEnvGracefulStopTimeout` covering: default (no env set), `IMGPROXY_TIMEOUT` changing the default, an explicit `IMGPROXY_GRACEFUL_STOP_TIMEOUT` overriding the derived default, and an explicit override with `IMGPROXY_TIMEOUT` unset.
- `CHANGELOG.md`: added a `Fixed` entry under `[4.1.0] - TBA`.


## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./server/...` — all pass, including the new subtests
- [x] `gofmt -l` — clean
